### PR TITLE
[24-01-29] eslint "arrow-body-style" rule 수정

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -20,7 +20,7 @@
     "no-var": "error",
     "no-multiple-empty-lines": "error",
     "eqeqeq": "error",
-    "arrow-body-style": ["error", "always"],
+    "arrow-body-style": ["error", "as-needed"],
     "react/react-in-jsx-scope": "off",
     "react/prop-types": 0
   },


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이 PR은 어떤 유형인가요?

- [x] 세팅 수정
- [ ] 기능
- [ ] 버그 수정
- [ ] 최적화
- [ ] 문서 업데이트

## 설명
- eslint의 "arrow-body-style" 룰을 "always"로 해두니까 화살표 함수를 쓸 때 필요없는 return 생겨서 "as-needed"로 변경합니다.

## 관련 티켓 및 문서

<!--
풀 리퀘스트가 관련되거나 문제를 해결하는 경우, 아래에 포함해 주세요. [Github의 문제 연결 가이드](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)를 따르고 싶습니다.).

예를 들어, "closes #1234"라는 텍스트가 현재 풀 리퀘스트와 1234번 이슈를 연결하고, 풀 리퀘스트가 병합되면 Github가 자동으로 이슈를 닫습니다.
-->

- Related Issue #21
- Closes #21
