### PR TITLE
[24-01-29 유미정] InvitationMembers 구현

### DIFF
--- a/src/components/common/InvitationMemebers/InvitationMembers.module.scss
+++ b/src/components/common/InvitationMemebers/InvitationMembers.module.scss
@@ -1,0 +1,35 @@
+.container {
+  @include inline-flexbox($gap: 0.6rem);
+
+  padding: 0.4rem 1.2rem 0.4rem 0.6rem;
+  border: 0.1rem solid $gray70;
+  border-radius: 10rem;
+
+  &:hover {
+    border: 0.1rem solid $gray40;
+  }
+}
+
+.members-list {
+  @include flexbox;
+
+  &::after {
+    width: 0.1rem;
+    height: 2.4rem;
+    margin-left: 0.4rem;
+    background-color: $gray70;
+    content: '';
+  }
+}
+
+.hidden-members-num {
+  @include flexbox;
+  @include text-style(12, $gray20);
+
+  width: 2.8rem;
+  margin: 0 0.2rem;
+  background-color: $gray70;
+  border-radius: 50%;
+  aspect-ratio: 1;
+  box-sizing: content-box;
+}

--- a/src/components/common/InvitationMemebers/index.jsx
+++ b/src/components/common/InvitationMemebers/index.jsx
@@ -1,44 +1,37 @@
-import { useEffect } from 'react';
-import styles from './InvitationMembers.module.scss';
 import classNames from 'classnames/bind';
+import styles from './InvitationMembers.module.scss';
 import useInvitationMembers from '@/hooks/useInvitationMembers';
-import Avatar from '@/components/common/avatar';
+import Avatar from '@/components/common/Avatar';
+import MixButton from '@/components/common/button/MixButton';
+import { Icon } from '@/constants/importImage';
 
 const cx = classNames.bind(styles);
 
 const InvitationMembers = ({ members }) => {
-  const { visibleMembersNum, handleInvitationMembers } = useInvitationMembers();
-
-  useEffect(() => {
-    handleInvitationMembers();
-  }, [visibleMembersNum, handleInvitationMembers]);
+  const { visibleMembersNum } = useInvitationMembers();
 
   return (
     <div className={cx('container')}>
       <ul className={cx('members-list')}>
         {members.length > visibleMembersNum
-          ? members.slice(0, visibleMembersNum).map((member) => {
-              return (
-                <li key={member.id}>
-                  <Avatar
-                    profileName={member.nickname}
-                    profileImage={member.profileImageUrl}
-                    avatarSize={'m'}
-                  />
-                </li>
-              );
-            })
-          : members.map((member) => {
-              return (
-                <li key={member.id}>
-                  <Avatar
-                    profileName={member.nickname}
-                    profileImage={member.profileImageUrl}
-                    avatarSize={'m'}
-                  />
-                </li>
-              );
-            })}
+          ? members.slice(0, visibleMembersNum).map((member) => (
+              <li key={member.id}>
+                <Avatar
+                  profileName={member.nickname}
+                  profileImage={member.profileImageUrl}
+                  avatarSize={'md'}
+                />
+              </li>
+            ))
+          : members.map((member) => (
+              <li key={member.id}>
+                <Avatar
+                  profileName={member.nickname}
+                  profileImage={member.profileImageUrl}
+                  avatarSize={'md'}
+                />
+              </li>
+            ))}
         {members.length > visibleMembersNum && (
           <li>
             <div className={cx('hidden-members-num')}>
@@ -47,6 +40,14 @@ const InvitationMembers = ({ members }) => {
           </li>
         )}
       </ul>
+      <MixButton
+        svg={Icon.add.default.url}
+        size={18}
+        type={'button'}
+        gap={4}
+        text={'Invite'}
+        fontSize={14}
+      />
     </div>
   );
 };

--- a/src/components/common/InvitationMemebers/index.jsx
+++ b/src/components/common/InvitationMemebers/index.jsx
@@ -1,9 +1,9 @@
 import classNames from 'classnames/bind';
-import styles from './InvitationMembers.module.scss';
 import useInvitationMembers from '@/hooks/useInvitationMembers';
 import Avatar from '@/components/common/Avatar';
 import MixButton from '@/components/common/button/MixButton';
-import { Icon } from '@/constants/importImage';
+import { ICON } from '@/constants/importImage';
+import styles from './InvitationMembers.module.scss';
 
 const cx = classNames.bind(styles);
 
@@ -19,7 +19,7 @@ const InvitationMembers = ({ members }) => {
                 <Avatar
                   profileName={member.nickname}
                   profileImage={member.profileImageUrl}
-                  avatarSize={'md'}
+                  avatarSize='md'
                 />
               </li>
             ))
@@ -28,7 +28,7 @@ const InvitationMembers = ({ members }) => {
                 <Avatar
                   profileName={member.nickname}
                   profileImage={member.profileImageUrl}
-                  avatarSize={'md'}
+                  avatarSize='md'
                 />
               </li>
             ))}
@@ -41,11 +41,11 @@ const InvitationMembers = ({ members }) => {
         )}
       </ul>
       <MixButton
-        svg={Icon.add.default.url}
+        svg={ICON.add.default.url}
         size={18}
-        type={'button'}
+        type='button'
         gap={4}
-        text={'Invite'}
+        text='Invite'
         fontSize={14}
       />
     </div>

--- a/src/components/common/InvitationMemebers/index.jsx
+++ b/src/components/common/InvitationMemebers/index.jsx
@@ -1,0 +1,54 @@
+import { useEffect } from 'react';
+import styles from './InvitationMembers.module.scss';
+import classNames from 'classnames/bind';
+import useInvitationMembers from '@/hooks/useInvitationMembers';
+import Avatar from '@/components/common/avatar';
+
+const cx = classNames.bind(styles);
+
+const InvitationMembers = ({ members }) => {
+  const { visibleMembersNum, handleInvitationMembers } = useInvitationMembers();
+
+  useEffect(() => {
+    handleInvitationMembers();
+  }, [visibleMembersNum, handleInvitationMembers]);
+
+  return (
+    <div className={cx('container')}>
+      <ul className={cx('members-list')}>
+        {members.length > visibleMembersNum
+          ? members.slice(0, visibleMembersNum).map((member) => {
+              return (
+                <li key={member.id}>
+                  <Avatar
+                    profileName={member.nickname}
+                    profileImage={member.profileImageUrl}
+                    avatarSize={'m'}
+                  />
+                </li>
+              );
+            })
+          : members.map((member) => {
+              return (
+                <li key={member.id}>
+                  <Avatar
+                    profileName={member.nickname}
+                    profileImage={member.profileImageUrl}
+                    avatarSize={'m'}
+                  />
+                </li>
+              );
+            })}
+        {members.length > visibleMembersNum && (
+          <li>
+            <div className={cx('hidden-members-num')}>
+              +{members.slice(visibleMembersNum).length}
+            </div>
+          </li>
+        )}
+      </ul>
+    </div>
+  );
+};
+
+export default InvitationMembers;

--- a/src/hooks/useInvitationMembers.js
+++ b/src/hooks/useInvitationMembers.js
@@ -1,0 +1,28 @@
+import { useState } from 'react';
+
+const useInvitationMembers = () => {
+  const [visibleMembersNum, setVisibleMembersNum] = useState(4);
+
+  const handleInvitationMembers = () => {
+    const handleResize = () => {
+      const currentWindowSize = window.innerWidth;
+
+      if (currentWindowSize > 375 && visibleMembersNum === 1) {
+        setVisibleMembersNum(4);
+      } else if (currentWindowSize <= 375 && visibleMembersNum === 4) {
+        setVisibleMembersNum(1);
+      }
+    };
+
+    handleResize();
+
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  };
+  return { visibleMembersNum, handleInvitationMembers };
+};
+
+export default useInvitationMembers;

--- a/src/hooks/useInvitationMembers.js
+++ b/src/hooks/useInvitationMembers.js
@@ -1,9 +1,9 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 const useInvitationMembers = () => {
   const [visibleMembersNum, setVisibleMembersNum] = useState(4);
 
-  const handleInvitationMembers = () => {
+  useEffect(() => {
     const handleResize = () => {
       const currentWindowSize = window.innerWidth;
 
@@ -21,8 +21,9 @@ const useInvitationMembers = () => {
     return () => {
       window.removeEventListener('resize', handleResize);
     };
-  };
-  return { visibleMembersNum, handleInvitationMembers };
+  }, [visibleMembersNum]);
+
+  return { visibleMembersNum };
 };
 
 export default useInvitationMembers;


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이 PR은 어떤 유형인가요?

- [x] 리팩터링
- [x] 기능
- [ ] 버그 수정
- [ ] 최적화
- [ ] 문서 업데이트

## 설명
### 해당 대시보드에 참여하는 멤버 리스트를 만들었습니다.

- Desktop과 Tablet 버전에서는 멤버 수가 4보다 클 때 맨 우측에 가려진 멤버 수를 보여주고
Mobile 버전에서는 멤버 수가 1보다 클 때 맨 우측에 가려진 멤버 수를 보여줍니다.

- 현재 멤버 수가 보여질 멤버 수보다 크다면 배열에서 보여질 멤버들만 추출하여 map으로 반환하고
그 외에는 현재 멤버들만 반환합니다.

## 관련 티켓 및 문서

<!--
풀 리퀘스트가 관련되거나 문제를 해결하는 경우, 아래에 포함해 주세요. [Github의 문제 연결 가이드](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)를 따르고 싶습니다.).

예를 들어, "closes #1234"라는 텍스트가 현재 풀 리퀘스트와 1234번 이슈를 연결하고, 풀 리퀘스트가 병합되면 Github가 자동으로 이슈를 닫습니다.
-->

- Related Issue #12 
- Closes #12 

## 스크린샷, 녹화
![image](https://github.com/TickyTocky/TickyTocky/assets/96277798/4ccd318f-83be-4d5e-a4b5-63938e3c14f1)
![image](https://github.com/TickyTocky/TickyTocky/assets/96277798/2a7dd1b6-615e-4cf8-800c-196254911aff)
![image](https://github.com/TickyTocky/TickyTocky/assets/96277798/880d2c2e-82f2-45c3-914b-ec874f9b0080)

