### PR TITLE
[24-01-31 유미정] Avatar 구현

### DIFF
--- a/public/svg/ic-arrow-down.svg
+++ b/public/svg/ic-arrow-down.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="icon / arrow">
+<path id="Vector" d="M12 15.375L6 9.37505L7.075 8.30005L12 13.25L16.925 8.32505L18 9.40005L12 15.375Z" fill="#6A6D81"/>
+</g>
+</svg>

--- a/public/svg/ic-arrow-up-active.svg
+++ b/public/svg/ic-arrow-up-active.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="icon / arrow">
+<path id="Vector" d="M12 8.62495L18 14.625L16.925 15.7L12 10.75L7.075 15.675L6 14.6L12 8.62495Z" fill="#37E8B4"/>
+</g>
+</svg>

--- a/public/svg/ic-arrow-up.svg
+++ b/public/svg/ic-arrow-up.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="icon / arrow">
+<path id="Vector" d="M12 8.62495L6 14.625L7.075 15.7L12 10.75L16.925 15.675L18 14.6L12 8.62495Z" fill="#E0E0E0"/>
+</g>
+</svg>

--- a/src/components/common/Avatar/Avatar.module.scss
+++ b/src/components/common/Avatar/Avatar.module.scss
@@ -39,7 +39,7 @@
 
 .text-color {
   &-gray10 {
-    @include text-style(16, $gray10, 'bold');
+    @include text-style(16, $gray10, bold);
   }
 
   &-gray20 {

--- a/src/components/common/Avatar/Avatar.module.scss
+++ b/src/components/common/Avatar/Avatar.module.scss
@@ -1,0 +1,70 @@
+%avatar-base {
+  position: relative;
+  border: 0.2rem solid transparent;
+  border-radius: 50%;
+  overflow: hidden;
+  aspect-ratio: 1;
+  box-sizing: content-box;
+}
+
+.container {
+  @include flexbox($jc: none, $gap: 0.8rem);
+}
+
+.avatar-size {
+  &-xl {
+    @extend %avatar-base;
+
+    width: 6.4rem;
+  }
+
+  &-lg {
+    @extend %avatar-base;
+
+    width: 3.8rem;
+  }
+
+  &-md {
+    @extend %avatar-base;
+
+    width: 2.8rem;
+  }
+
+  &-sm {
+    @extend %avatar-base;
+
+    width: 2.4rem;
+  }
+}
+
+.text-color {
+  &-gray10 {
+    @include text-style(16, $gray10, 'bold');
+  }
+
+  &-gray20 {
+    @include text-style(16, $gray20);
+  }
+}
+
+.active {
+  border: 0.2rem solid $primary;
+}
+
+.image {
+  @include image-fit;
+}
+
+.badge {
+  @include flexbox;
+  @include text-style(16, $white, bold);
+  @include image-fit;
+
+  background-color: $purple;
+}
+
+.text-icon-wrap {
+  @include flexbox($gap: 0.2rem);
+
+  cursor: pointer;
+}

--- a/src/components/common/Avatar/index.jsx
+++ b/src/components/common/Avatar/index.jsx
@@ -1,0 +1,52 @@
+import Image from 'next/image';
+import classNames from 'classnames/bind';
+import useToggleButton from '@/hooks/useToggleButton';
+import { ICON } from '@/constants/importImage';
+import styles from './Avatar.module.scss';
+
+const cx = classNames.bind(styles);
+const { arrowUp, arrowDown } = ICON;
+
+const Avatar = ({
+  profileImage,
+  profileName,
+  textColor,
+  avatarSize = 'xl',
+  isArrow = false,
+}) => {
+  const { isVisible, handleToggleClick } = useToggleButton();
+
+  return (
+    <div className={cx('container')}>
+      <div
+        className={cx(`avatar-size-${avatarSize}`, {
+          active: isVisible,
+        })}
+      >
+        {profileImage ? (
+          <Image className={cx('image')} src={profileImage} alt='profile-image' fill />
+        ) : (
+          <div className={cx('badge')}>{profileName.charAt(0)}</div>
+        )}
+      </div>
+      {textColor && (
+        <div className={cx('text-icon-wrap')} onClick={handleToggleClick}>
+          <span className={cx(`text-color-${textColor}`)}>{profileName}</span>
+          {isArrow &&
+            (isVisible ? (
+              <Image
+                src={arrowUp.active.url}
+                alt={arrowUp.active.alt}
+                width={16}
+                height={16}
+              />
+            ) : (
+              <Image src={arrowDown.url} alt={arrowDown.alt} width={16} height={16} />
+            ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Avatar;

--- a/src/constants/importImage.js
+++ b/src/constants/importImage.js
@@ -4,6 +4,9 @@ import IconLogoutHover from 'public/svg/ic-logout-hover.svg';
 import IconNavActive from 'public/svg/ic-nav-active.svg';
 import IconNav from 'public/svg/ic-nav.svg';
 import IconDelete from 'public/svg/ic-delete.svg';
+import IconArrowUp from 'public/svg/ic-arrow-up.svg';
+import IconArrowUpActive from 'public/svg/ic-arrow-up-active.svg';
+import IconArrowDown from 'public/svg/ic-arrow-down.svg';
 
 export const ICON = {
   add: {
@@ -34,8 +37,22 @@ export const ICON = {
       alt: 'icon-nav',
     },
   },
-   delete: {
+  delete: {
     url: IconDelete,
     alt: 'icon-delete',
+  },
+  arrowUp: {
+    default: {
+      url: IconArrowUp,
+      alt: 'icon-arrow-up',
+    },
+    active: {
+      url: IconArrowUpActive,
+      alt: 'icon-arrow-up-active',
+    },
+  },
+  arrowDown: {
+    url: IconArrowDown,
+    alt: 'icon-arrow-down',
   },
 };


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이 PR은 어떤 유형인가요?

- [x] 리팩터링
- [x] 기능
- [ ] 버그 수정
- [ ] 최적화
- [ ] 문서 업데이트

## 설명

### 프로필에 사용될 Avatar를 만들었습니다.

**전달 받는 props**
- `profileImage` : 전달 받았을 때 해당 이미지가 나타나고 전달 받지 못했을 때는 이름의 앞글자만 보이는 `bedge`가 나타납니다.
- `profileName` : 필수로 전달 받아야 하고 프로필 이름에 사용됩니다.
- `avatarSize` : 기본값은 `xl` 사이즈입니다. 해당 `prop`을 받아서 `className`에 넣고 `profileImage`의 사이즈를 조절합니다.
- `textColor` : 이름의 색상을 설정하는 `prop`입니다. 전달 받지 못하면 이름과 화살표는 보이지 않습니다.
- `isArrow` : 화살표의 유무를 설정하는 `prop`입니다. 전달 받지 못하면 화살표는 보이지 않습니다. `isArrow`를 전달 받아도 `textColor` 전달 받지 못하면 화살표는 보이지 않습니다.

⭐ 프로필 이름 클릭 시 프로필 사진의 테두리가 적용됩니다.

## 관련 티켓 및 문서

<!--
풀 리퀘스트가 관련되거나 문제를 해결하는 경우, 아래에 포함해 주세요. [Github의 문제 연결 가이드](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)를 따르고 싶습니다.).

예를 들어, "closes #1234"라는 텍스트가 현재 풀 리퀘스트와 1234번 이슈를 연결하고, 풀 리퀘스트가 병합되면 Github가 자동으로 이슈를 닫습니다.
-->

- Related Issue #4 
- Closes #4 

## 스크린샷, 녹화

![image](https://github.com/TickyTocky/TickyTocky/assets/96277798/949acf13-83c5-4975-b6a5-985604267003)
![image](https://github.com/TickyTocky/TickyTocky/assets/96277798/ca6ee480-275c-4577-b44b-46eb87e7540d)

