### PR TITLE
[24-01-31 유미정] ProfileModal 구현

### DIFF
--- a/src/components/common/ProfileModal/ProfileModal.module.scss
+++ b/src/components/common/ProfileModal/ProfileModal.module.scss
@@ -1,0 +1,31 @@
+.container {
+  @include column-flexbox($gap: 2.4rem);
+
+  width: 30.4rem;
+  padding: 3rem;
+  border: 0.2rem solid $gray70;
+  border-radius: 1.6rem;
+  box-shadow: $dropdown-shadow;
+}
+
+.profile {
+  @include column-flexbox;
+}
+
+.name {
+  @include text-style(16, $gray10, bold);
+
+  margin-top: 1.4rem;
+}
+
+.email {
+  @include text-style(14, $gray20);
+
+  margin-top: 0.4rem;
+}
+
+.button-wrap {
+  @include column-flexbox($gap: 1.2rem);
+
+  width: 100%;
+}

--- a/src/components/common/ProfileModal/index.jsx
+++ b/src/components/common/ProfileModal/index.jsx
@@ -1,0 +1,22 @@
+import classNames from 'classnames/bind';
+import Avatar from '@/components/common/Avatar';
+import BaseButton from '@/components/common/button/BaseButton';
+import styles from './ProfileModal.module.scss';
+
+const cx = classNames.bind(styles);
+
+const ProfileModal = ({ profileName, profileImage, profileEmail }) => (
+  <div className={cx('container')}>
+    <div className={cx('profile')}>
+      <Avatar profileImage={profileImage} avatarSize='xl' />
+      <span className={cx('name')}>{profileName}</span>
+      <span className={cx('email')}>{profileEmail}</span>
+    </div>
+    <div className={cx('button-wrap')}>
+      <BaseButton size='xl' variant='outline' type='button' text='My Page' />
+      <BaseButton size='xl' variant='ghost' type='button' text='Logout' />
+    </div>
+  </div>
+);
+
+export default ProfileModal;


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이 PR은 어떤 유형인가요?

- [x] 리팩터링
- [x] 기능
- [ ] 버그 수정
- [ ] 최적화
- [ ] 문서 업데이트

## 설명

### myHeader의 프로필 클릭 시 띄워질 ProfileModal을 만들었습니다.

전달 받는 props
- `profileName`, `profileEmail` : 모달에 유저의 이름, 이메일이 나타납니다.
- `profileImage` : Avatar 컴포넌트로 전달해 프로필 사진을 나타나게 합니다.


## 관련 티켓 및 문서

<!--
풀 리퀘스트가 관련되거나 문제를 해결하는 경우, 아래에 포함해 주세요. [Github의 문제 연결 가이드](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)를 따르고 싶습니다.).

예를 들어, "closes #1234"라는 텍스트가 현재 풀 리퀘스트와 1234번 이슈를 연결하고, 풀 리퀘스트가 병합되면 Github가 자동으로 이슈를 닫습니다.
-->

- Related Issue #10 
- Closes #10 

## 스크린샷, 녹화
![image](https://github.com/TickyTocky/TickyTocky/assets/96277798/03408831-1402-4dab-a4df-e2ca10c35e76)

