### PR TITLE
[24-01-31 고성선] button 컴포넌트 focus 미적용 및 iconSize 16x16 추가

### DIFF
--- a/src/components/common/button/Button.module.scss
+++ b/src/components/common/button/Button.module.scss
@@ -30,7 +30,8 @@
     @include text-style(14, $gray70);
   }
 
-  &:hover:not(:disabled) {
+  &:hover:not(:disabled),
+  &:focus:not(:disabled) {
     background-color: $green;
 
     @include responsive(M) {
@@ -46,7 +47,8 @@
   &.btn-lg {
     @include text-style(16, $primary, bold);
 
-    &:hover:not(:disabled) {
+    &:hover:not(:disabled),
+    &:focus:not(:disabled) {
       color: $gray70;
 
       @include responsive(M) {
@@ -59,7 +61,8 @@
   &.btn-sm {
     @include text-style(14, $primary);
 
-    &:hover:not(:disabled) {
+    &:hover:not(:disabled),
+    &:focus:not(:disabled) {
       color: $gray70;
 
       @include responsive(M) {
@@ -70,7 +73,8 @@
 
   background-color: $black;
 
-  &:hover:not(:disabled) {
+  &:hover:not(:disabled),
+  &:focus:not(:disabled) {
     background-color: $primary;
 
     @include responsive(M) {
@@ -94,7 +98,8 @@
 
   background-color: $gray70;
 
-  &:hover:not(:disabled) {
+  &:hover:not(:disabled),
+  &:focus:not(:disabled) {
     background-color: $gray50;
 
     @include responsive(M) {
@@ -110,7 +115,8 @@
   &.btn-lg {
     @include text-style(16, $gray40, bold);
 
-    &:hover:not(:disabled) {
+    &:hover:not(:disabled),
+    &:focus:not(:disabled) {
       color: $gray10;
 
       @include responsive(M) {
@@ -123,7 +129,8 @@
   &.btn-sm {
     @include text-style(14, $gray40);
 
-    &:hover:not(:disabled) {
+    &:hover:not(:disabled),
+    &:focus:not(:disabled) {
       color: $gray10;
 
       @include responsive(M) {
@@ -134,7 +141,8 @@
 
   border: 1px solid $gray40;
 
-  &:hover:not(:disabled) {
+  &:hover:not(:disabled),
+  &:focus:not(:disabled) {
     border: 1px solid $gray10;
 
     @include responsive(M) {
@@ -150,7 +158,8 @@
   &.btn-lg {
     @include text-style(16, $red, bold);
 
-    &:hover {
+    &:hover:not(:disabled),
+    &:focus:not(:disabled) {
       color: $gray10;
       @include responsive(M) {
         color: $red;
@@ -162,7 +171,8 @@
   &.btn-sm {
     @include text-style(14, $red);
 
-    &:hover {
+    &:hover:not(:disabled),
+    &:focus:not(:disabled) {
       color: $gray10;
 
       @include responsive(M) {
@@ -173,7 +183,8 @@
 
   background-color: $black;
 
-  &:hover:not(:disabled) {
+  &:hover:not(:disabled),
+  &:focus:not(:disabled) {
     background-color: $red;
 
     @include responsive(M) {

--- a/src/components/common/button/IconButton.jsx
+++ b/src/components/common/button/IconButton.jsx
@@ -4,7 +4,16 @@ import styles from './IconButton.module.scss';
 
 const cx = classNames.bind(styles);
 
-const IconButton = ({ svg, size, alt, outline, isActive, type = 'button', ...props }) => (
+const IconButton = ({
+  svg,
+  size,
+  alt,
+  outline,
+  isActive,
+  type = 'button',
+  iconSize = '24',
+  ...props
+}) => (
   <button
     type={type}
     className={cx(
@@ -15,7 +24,7 @@ const IconButton = ({ svg, size, alt, outline, isActive, type = 'button', ...pro
     )}
     {...props}
   >
-    <div className={cx('ic-box')}>
+    <div className={cx(`ic-box-${iconSize}`)}>
       <Image src={svg} alt={alt} className={cx('ic-fit')} />
     </div>
   </button>

--- a/src/components/common/button/IconButton.module.scss
+++ b/src/components/common/button/IconButton.module.scss
@@ -20,29 +20,41 @@
 }
 
 .ic-btn-outline {
-  border: 1px solid $gray70;
+  border: 0.1rem solid $gray70;
 
-  &:hover {
-    border: 1px solid $gray30;
+  &:hover:not(:disabled) {
+    border: 0.1rem solid $gray30;
 
     @include responsive(M) {
-      border: 1px solid $gray70;
+      border: 0.1rem solid $gray70;
     }
   }
 
-  &-active {
-    border: 1px solid $primary;
+  &:focus:not(:disabled) {
+    border: 0.1rem solid $primary;
+  }
 
-    &:hover {
-      border: 1px solid $primary;
+  &-active {
+    border: 0.1rem solid $primary;
+
+    &:hover:not(:disabled) {
+      border: 0.1rem solid $primary;
     }
   }
 }
 
 .ic-box {
   position: relative;
-  width: 2.4rem;
-  height: 2.4rem;
+
+  &-24 {
+    width: 2.4rem;
+    height: 2.4rem;
+  }
+
+  &-16 {
+    width: 1.6rem;
+    height: 1.6rem;
+  }
 }
 
 .ic-fit,


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이 PR은 어떤 유형인가요?

- [ ] 리팩터링
- [ ] 기능
- [x] 버그 수정
- [ ] 최적화
- [ ] 문서 업데이트

## 설명
base, icon버튼의 focus 를 미적용한건 및 IconButton의 iconSize를 추가하였습니다. 16x16 
## 관련 티켓 및 문서

<!--
풀 리퀘스트가 관련되거나 문제를 해결하는 경우, 아래에 포함해 주세요. [Github의 문제 연결 가이드](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)를 따르고 싶습니다.).

예를 들어, "closes #1234"라는 텍스트가 현재 풀 리퀘스트와 1234번 이슈를 연결하고, 풀 리퀘스트가 병합되면 Github가 자동으로 이슈를 닫습니다.
-->

- Related Issue #40 
- Closes #40

## 스크린샷, 녹화

_변경사항을 테스트하는 방법, 테스트에 사용된 기기 및 브라우저, UI 변경에 대한 관련 이미지 등에 대한 지침을 이곳에 기재해 주세요._

### UI 접근성 체크리스트

_UI 변경 사항이 있는 경우, 이 체크리스트를 활용하세요:_

- [ ] Semantic HTML 구현?
- [ ] 키보드 조작이 지원?
- [ ] [axe DevTools](https://www.deque.com/axe/)를 사용하여 Critical 및 Serious 문제를 확인하고 해결했나요?

## [선택사항] 이 PR을 가장 잘 설명하는 GIF는 무엇인가요?
![happy-friday-dance (1)](https://github.com/TickyTocky/TickyTocky/assets/148178373/cfe55b27-2f3c-4d29-9f09-a53e781aa750)
