### PR TITLE
[24-02-02 우준석] 총 태그 숫자 8개로 제한, 글자숫자 8글자로제한, 같은 태그가 추가되지 않도록 코드 변경, 삭제 버튼 호버시 커서 포인터로 변경, 태그가 생성될때 input의 범위를 덮어버리고 왼쪽부터 생성되는 문제 해결

### DIFF
--- a/src/components/common/TagField/TagField.module.scss
+++ b/src/components/common/TagField/TagField.module.scss
@@ -73,6 +73,7 @@
 
   &:hover {
     filter: brightness(1000%);
+    cursor: pointer;
   }
 }
 

--- a/src/components/common/TagField/TagField.module.scss
+++ b/src/components/common/TagField/TagField.module.scss
@@ -11,7 +11,6 @@
 .tagsinput-tags {
   @include flexbox(start, center, 0.8rem);
 
-  flex-wrap: nowrap;
   width: 100%;
   height: 4.8rem;
   padding: 0 1.6rem;
@@ -19,6 +18,7 @@
   border-radius: 0.6rem;
   background-color: $gray70;
   overflow: hidden;
+  flex-wrap: nowrap;
   transition: $base-transition;
 
   li:nth-child(5n + 1) {
@@ -47,8 +47,11 @@
 }
 
 .tagsinput-tags-list {
-  @include inline-flexbox(start, center, 0.8rem);
+  @include no-scrollbar;
+  @include inline-flexbox(end, center, 0.8rem);
 
+  max-width: 100%;
+  overflow: scroll;
   flex-wrap: nowrap;
 }
 
@@ -80,6 +83,7 @@
 .tagsinput-input {
   @include text-style(16, $gray10);
 
+  min-width: 20%;
   width: 100%;
   height: 2.4rem;
   background: transparent;
@@ -87,6 +91,7 @@
   outline: none;
   cursor: text;
   white-space: nowrap;
+  flex: 1 1;
 
   &::placeholder {
     @include text-style(16, $gray40);

--- a/src/components/common/TagField/index.jsx
+++ b/src/components/common/TagField/index.jsx
@@ -28,7 +28,9 @@ const TagField = ({ tagList, setTagList }) => {
   };
 
   const handleSubmitTagItem = () => {
-    setTagList((prev) => [...prev, tagItem]);
+    if (!tagList.includes(tagItem)) {
+      setTagList((prev) => [...prev, tagItem]);
+    }
     setTagItem('');
   };
 

--- a/src/components/common/TagField/index.jsx
+++ b/src/components/common/TagField/index.jsx
@@ -11,6 +11,8 @@ const TagField = ({ tagList, setTagList }) => {
   const [tagItem, setTagItem] = useState('');
 
   const MINIMUM_LENGTH = 5;
+  const MAXIMUM_LENGTH = 8;
+  const MAX_TAG_COUNT = 8;
 
   const handleKeyPress = (e) => {
     if (tagItem.length !== 0 && e.key === 'Enter') {
@@ -28,7 +30,11 @@ const TagField = ({ tagList, setTagList }) => {
   };
 
   const handleSubmitTagItem = () => {
-    if (!tagList.includes(tagItem)) {
+    if (
+      !tagList.includes(tagItem) &&
+      tagItem.length <= MAXIMUM_LENGTH &&
+      tagList.length < MAX_TAG_COUNT
+    ) {
       setTagList((prev) => [...prev, tagItem]);
     }
     setTagItem('');


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이 PR은 어떤 유형인가요?

- [ ] 리팩터링
- [ ] 기능
- [x] 버그 수정
- [ ] 최적화
- [ ] 문서 업데이트


- Related Issue #58, #
- Closes #58  


## 설명
같은 태그가 추가되지 않도록 코드를 변경하였습니다.
삭제 버튼 호버시 커서 포인터로 변경하였습니다.
태그가 생성될때 input의 범위를 덮어버리고 왼쪽부터 생성되는 문제를 해결했습니다
태그의 총 숫자가 8개를 넘지 않도록 수정하고, 태그의 글자 길이도 8글자를 넘지 않도록 했습니다.

## 스크린샷, 녹화

![image](https://github.com/TickyTocky/TickyTocky/assets/40357804/d03fd041-c155-473d-b98b-22593861e20f)
