### PR TITLE
[24-02-03 허우림] useModalState 훅 구현

### DIFF
--- a/src/hooks/useModalState.js
+++ b/src/hooks/useModalState.js
@@ -1,0 +1,18 @@
+import { useState } from 'react';
+
+const useModalState = (ids) => {
+  const [modalState, setModalState] = useState(
+    ids.reduce((acc, id) => {
+      acc[id] = false;
+      return acc;
+    }, {})
+  );
+
+  const toggleModal = (id) => {
+    setModalState((prev) => ({ ...prev, [id]: !prev[id] }));
+  };
+
+  return { modalState, toggleModal };
+};
+
+export default useModalState;


### PR DESCRIPTION
## 기존 useModalStore의 문제 및 해결
- 전역상태로 모달의 상태를 관리하다보니, 동시에 여러 컴포넌트에서 동일한 모달의 상태를 사용할 수 없었습니다. 그래서 전역상태가 아닌 컴포넌트 안에서의 상태로 관리하도록 대신 만들었습니다.
- 모달의 개수만큼 state를 만드는 것이 아니라, 훅의 인자로 들어오는 배열의 요소 개수만큼 동적으로 state의 프로퍼티가 만들어지도록 했습니다.

## 📌 코드 살펴보기

### state 선언

```jsx
const [modalState, setModalState] = useState(
    ids.reduce((acc, id) => {
      acc[id] = false;
      return acc;
    }, {})
  );
```

- ids 배열로 들어오는 애들을 reduce로 초기값부터 누적해서 객체에 false로 넣는다.

```jsx
const toggleModal = (id) => {
    setModalState((prev) => ({ ...prev, [id]: !prev[id] }));
  };
```

- toggleModal이라는 함수에 id를 전달해주면, 그 state에서 id를 프로퍼티로 가진 애의 벨류를 지금과 반대로 해준다.

## 📌 바로 사용하기

```jsx
import **useModalState** from '@/hooks/**useModalState**';

const { modalState, toggleModal } = useModalState(['사용하는모달개수만큼', '배열로모달이름주기']);

return (
     <button onClick={() => toggleModal('common')}>common 모달켜기</button>
      <CommonModal
        isModalOpen={modalState.common}
        closeModal={() => toggleModal('common')} 
        label='라벨'
      >
        <div>자식</div>
      </CommonModal>
    </>
  );
```

- ⚠️ onClick에 `콜백`으로 전달 안 하면 무한렌더링 오류 발생
- toggleModal 사용할 때는 무조건 콜백으로 사용하고, 모달 이름 인자로 전달하기

related issue #80 
closes #80 