### PR TITLE
[24-02-04 허우림]  AuthForm에 login signup메소드 적용

### DIFF
--- a/src/components/auth/login/AuthForm.jsx
+++ b/src/components/auth/login/AuthForm.jsx
@@ -1,11 +1,10 @@
-import React from 'react';
 import Link from 'next/link';
 import classNames from 'classnames/bind';
 import { useFormContext } from 'react-hook-form';
 import InputField from '@/components/common/InputField';
 import FormHeader from '@/components/auth/common/FormHeader';
 import BaseButton from '@/components/common/button/BaseButton';
-import auth from '@/api/auth';
+import { login } from '@/api/auth';
 import styles from './AuthForm.module.scss';
 
 const cx = classNames.bind(styles);
@@ -14,7 +13,7 @@ const AuthForm = () => {
   const { handleSubmit, setError } = useFormContext();
 
   const onSubmit = (data) => {
-    auth('login', data, setError);
+    login(data, setError);
   };
 
   return (

--- a/src/components/auth/signup/AuthForm.jsx
+++ b/src/components/auth/signup/AuthForm.jsx
@@ -1,11 +1,10 @@
-import React from 'react';
 import Link from 'next/link';
 import classNames from 'classnames/bind';
+import { useFormContext } from 'react-hook-form';
 import InputField from '@/components/common/InputField';
 import FormHeader from '@/components/auth/common/FormHeader';
 import BaseButton from '@/components/common/button/BaseButton';
-import { useFormContext } from 'react-hook-form';
-import auth from '@/api/auth';
+import { signup } from '@/api/auth';
 import styles from './AuthForm.module.scss';
 
 const cx = classNames.bind(styles);
@@ -14,7 +13,7 @@ const AuthForm = () => {
   const { handleSubmit, setError } = useFormContext();
 
   const onSubmit = (data) => {
-    auth('signup', data, setError);
+    signup(data, setError);
   };
 
   return (


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이 PR은 어떤 유형인가요?

- [x] 리팩터링
- [x] 기능
- [ ] 버그 수정
- [ ] 최적화
- [ ] 문서 업데이트

## 설명
- login signup하는 AuthForm에 새로운 메소드 적용
- import문 컨벤션에 맞게 수정

## 관련 티켓 및 문서

<!--
풀 리퀘스트가 관련되거나 문제를 해결하는 경우, 아래에 포함해 주세요. [Github의 문제 연결 가이드](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)를 따르고 싶습니다.).

예를 들어, "closes #1234"라는 텍스트가 현재 풀 리퀘스트와 1234번 이슈를 연결하고, 풀 리퀘스트가 병합되면 Github가 자동으로 이슈를 닫습니다.
-->

- Related Issue #
- Closes #