### PR TITLE
[24-02-08 허우림] DashboardList, DashboardCard 구현 및 CreateDashboard 리팩토링

### DIFF
--- a/src/components/dashboard/DashboardCard/DashboardCard.module.scss
+++ b/src/components/dashboard/DashboardCard/DashboardCard.module.scss
@@ -1,0 +1,51 @@
+.dashboard-article {
+  position: relative;
+  width: 100%;
+  min-width: 32.2rem;
+  height: 10.6rem;
+  padding: 2.4rem 2.4rem 2.4rem 0;
+  background: $gray80;
+  border-radius: 0.6rem;
+  border: 0.1rem solid rgba(0 0 0 / 0%);
+  transition: all ease-in-out 0.3s;
+
+  &-side-pointer {
+    @include pos-center-y;
+
+    left: -0.1rem;
+    width: 0.4rem;
+    height: 3.2rem;
+    border-radius: 0 0.8rem 0.8rem 0;
+    background: $primary;
+    z-index: $modal-level;
+  }
+
+  &:hover {
+    cursor: pointer;
+    border: 0.1rem solid transparent;
+    transform: translateY(-1rem);
+  }
+
+  &-container {
+    @include column-flexbox(center, start, 1rem);
+
+    width: 100%;
+    padding-left: 2.4rem;
+
+    &-board-name {
+      @include text-style(16, $gray10);
+    }
+
+    &-contents {
+      @include flexbox(between, center);
+
+      width: 100%;
+      height: 2.4rem;
+
+      &-container {
+        @include flexbox(center, center, 0.4rem);
+        @include text-style(12, $gray30, bold);
+      }
+    }
+  }
+}

--- a/src/components/dashboard/DashboardCard/index.jsx
+++ b/src/components/dashboard/DashboardCard/index.jsx
@@ -1,0 +1,71 @@
+import Image from 'next/image';
+import classNames from 'classnames/bind';
+import Avatar from '@/components/common/Avatar';
+import useToggleButton from '@/hooks/useToggleButton';
+import { ICON } from '@/constants/importImage';
+import styles from './DashboardCard.module.scss';
+
+const cx = classNames.bind(styles);
+const { calendar } = ICON;
+
+const DashboardCard = ({
+  dashboard = {
+    color: '#000000',
+    title: '',
+    createdAt: '',
+    createdByMe: false,
+  },
+  member = {
+    profileImage: '',
+    profileName: 'H',
+  },
+}) => {
+  const { isVisible, handleToggleClick } = useToggleButton();
+
+  return (
+    <article
+      style={{
+        border: isVisible
+          ? dashboard.color
+            ? `0.1rem solid ${dashboard.color}`
+            : '0.1rem solid transparent;'
+          : '',
+      }}
+      onMouseOver={handleToggleClick}
+      onMouseOut={handleToggleClick}
+      className={cx('dashboard-article')}
+    >
+      <div
+        style={{ background: dashboard.color ? `${dashboard.color}` : '#ffffff' }}
+        className={cx('dashboard-article-side-pointer')}
+      ></div>
+      <div className={cx('dashboard-article-container')}>
+        <header className={cx('dashboard-article-container-board-name')}>
+          {dashboard.title}
+        </header>
+        <div className={cx('dashboard-article-container-contents')}>
+          <div className={cx('dashboard-article-container-contents-container')}>
+            <Image
+              src={calendar.default.url}
+              alt={calendar.default.alt}
+              width={18}
+              height={18}
+            />
+            <span>{dashboard.createdAt?.split('T')[0]}</span>
+          </div>
+          <div>
+            {dashboard.createdByMe && (
+              <Avatar
+                avatarSize='sm'
+                profileImage={member.profileImage}
+                profileName={member.profileName}
+              />
+            )}
+          </div>
+        </div>
+      </div>
+    </article>
+  );
+};
+
+export default DashboardCard;

--- a/src/components/dashboard/DashboardList/DashboardList.module.scss
+++ b/src/components/dashboard/DashboardList/DashboardList.module.scss
@@ -1,0 +1,197 @@
+.dashboard-list-container {
+  @include column-flexbox(center, start, 2.4rem);
+
+  margin: 12.6rem auto;
+  max-width: 136rem;
+
+  @include responsive(MP) {
+    max-width: 101.4rem;
+  }
+
+  @include responsive(T) {
+    max-width: 66.8rem;
+  }
+
+  @include responsive(M) {
+    @include no-scrollbar;
+
+    width: 100%;
+    padding: 0 1.5rem;
+  }
+
+  &-header {
+    @include flexbox(start, center, 1.6rem);
+
+    &-container {
+      @include flexbox($gap: 0.8rem);
+
+      .dashboard-name {
+        @include text-style(24, $white, bold);
+
+        margin-right: auto;
+      }
+
+      .dashboard-number {
+        @include text-style(12, $gray20, bold);
+
+        height: 2.4rem;
+        padding: 0.5rem;
+        border-radius: 0.4rem;
+        background: $gray70;
+      }
+    }
+  }
+
+  &-section {
+    @include column-flexbox(start, start, 3.2rem);
+
+    width: 100%;
+    height: 57.6rem;
+    overflow: hidden;
+
+    @include responsive(MT) {
+      width: auto;
+    }
+
+    @include responsive(T) {
+      width: auto;
+      height: auto;
+    }
+
+    @include responsive(M) {
+      width: 100%;
+      height: auto;
+      align-items: center;
+    }
+
+    &-header {
+      @include flexbox(between);
+
+      width: 100%;
+
+      @include responsive(M) {
+        flex-direction: column-reverse;
+        align-items: start;
+        gap: 1.6rem;
+      }
+
+      &-filter {
+        @include flexbox(start, center, 1.2rem);
+
+        @include responsive(M) {
+          @include no-scrollbar;
+
+          width: 100%;
+          overflow-x: scroll;
+        }
+
+        .all,
+        .my,
+        .invited {
+          @include text-style(16, $gray10, bold);
+
+          height: 4rem;
+          padding: 0 1.6rem;
+          border: 0.1rem solid $gray70;
+          border-radius: 3rem;
+          white-space: nowrap;
+
+          &:hover,
+          &:active,
+          &:focus {
+            color: $gray90;
+            background: $primary;
+            box-shadow: $dashboard-shadow;
+          }
+        }
+
+        .all.active,
+        .my.active,
+        .invited.active {
+          color: $gray90;
+          background: $primary;
+        }
+      }
+
+      &-dropdown-container {
+        @include flexbox($gap: 1.6rem);
+
+        @include responsive(M) {
+          width: 100%;
+          justify-content: space-between;
+          flex-direction: row-reverse;
+        }
+
+        &-dropdown {
+          @include responsive(M) {
+            width: 100%;
+          }
+        }
+
+        &-create-button {
+          display: none;
+
+          @include responsive(M) {
+            width: 12rem;
+            display: block;
+          }
+        }
+      }
+    }
+
+    &-card-container {
+      display: grid;
+      grid-template-columns: repeat(4, auto);
+      gap: 2.4rem;
+
+      @include responsive(MP) {
+        grid-template-columns: repeat(3, auto);
+      }
+
+      @include responsive(T) {
+        @include no-scrollbar;
+
+        grid-template-columns: repeat(2, auto);
+      }
+
+      @include responsive(M) {
+        @include no-scrollbar;
+
+        width: 100%;
+        padding-top: 1.2rem;
+        grid-template-columns: repeat(1, auto);
+        overflow-x: hidden;
+      }
+    }
+  }
+
+  &-footer {
+    @include flexbox(between, center);
+    @include text-style(16, $gray30);
+
+    width: 100%;
+
+    @include responsive(M) {
+      display: none;
+    }
+
+    &-current-page {
+      color: $gray10;
+    }
+  }
+
+  &-pagination-container {
+    border: 0.1rem solid $gray60;
+    border-radius: 0.4rem;
+
+    &-button-left {
+      padding: 1.2rem;
+      border-right: 0.1rem solid $gray60;
+    }
+
+    &-button-right {
+      padding: 1.2rem;
+      border-left: 0.1rem solid $gray60;
+    }
+  }
+}

--- a/src/components/dashboard/DashboardList/index.jsx
+++ b/src/components/dashboard/DashboardList/index.jsx
@@ -1,0 +1,128 @@
+import Image from 'next/image';
+import classNames from 'classnames/bind';
+import BaseButton from '@/components/common/button/BaseButton';
+import DashboardCard from '@/components/dashboard/DashboardCard';
+import DropDown from '@/components/common/DropDown';
+import CreateDashboard from '@/components/dashboard/modal/dashboard/CreateDashboard';
+import useDashboardList from '@/hooks/useDashboardList';
+import useModalState from '@/hooks/useModalState';
+import { ICON } from '@/constants/importImage';
+import styles from './DashboardList.module.scss';
+
+const cx = classNames.bind(styles);
+const { page } = ICON;
+const { arrowLeft, arrowRight } = page;
+
+const DashboardList = ({ dashboardData }) => {
+  const {
+    currentPageData,
+    currentFilter,
+    handleFilterClick,
+    handleDropdownClick,
+    currentPage,
+    totalPages,
+    goToPrevPage,
+    goToNextPage,
+  } = useDashboardList(dashboardData);
+  const { modalState, toggleModal } = useModalState(['createDashboard']);
+
+  return (
+    <div className={cx('dashboard-list-container')}>
+      <CreateDashboard
+        isModalOpen={modalState.createDashboard}
+        toggleModal={toggleModal}
+      />
+      <header className={cx('dashboard-list-container-header')}>
+        <div className={cx('dashboard-list-container-header-container')}>
+          <span className={cx('dashboard-name')}>Dashboard</span>
+          <div className={cx('dashboard-number')}>{dashboardData.totalCount}</div>
+        </div>
+      </header>
+      <section className={cx('dashboard-list-container-section')}>
+        <div className={cx('dashboard-list-container-section-header')}>
+          <div className={cx('dashboard-list-container-section-header-filter')}>
+            <button
+              onClick={() => handleFilterClick('All')}
+              className={cx('all', { active: currentFilter === 'All' })}
+            >
+              All
+            </button>
+            <button
+              onClick={() => handleFilterClick('My Dashboard')}
+              className={cx('my', { active: currentFilter === 'My Dashboard' })}
+            >
+              My Dashboard
+            </button>
+            <button
+              onClick={() => handleFilterClick('Invited Dashboard')}
+              className={cx('invited', { active: currentFilter === 'Invited Dashboard' })}
+            >
+              Invited Dashboard
+            </button>
+          </div>
+          <div
+            className={cx('dashboard-list-container-section-header-dropdown-container')}
+          >
+            <DropDown
+              className={cx(
+                'dashboard-list-container-section-header-dropdown-container-dropdown'
+              )}
+              onClickInput={handleDropdownClick}
+              type='timeline'
+            />
+            <div
+              className={cx(
+                'dashboard-list-container-section-header-dropdown-container-create-button'
+              )}
+            >
+              <BaseButton
+                onClick={() => toggleModal('createDashboard')}
+                variant='secondary'
+                size='xl'
+                text='Create'
+              />
+            </div>
+          </div>
+        </div>
+        <div className={cx('dashboard-list-container-section-card-container')}>
+          {currentPageData.map((dashboard, i) => (
+            <DashboardCard key={`dashboard-${dashboard.id}+${i}`} dashboard={dashboard} />
+          ))}
+        </div>
+      </section>
+      <footer className={cx('dashboard-list-container-footer')}>
+        <div className={cx('dashboard-list-container-footer-page-container')}>
+          <span
+            className={cx('dashboard-list-container-footer-page-container-current-page')}
+          >
+            {currentPage}
+          </span>
+          <span
+            className={cx('dashboard-list-container-footer-page-container-total-page')}
+          >
+            /{totalPages}
+          </span>
+        </div>
+        <div className={cx('dashboard-list-container-footer-pagination-container')}>
+          <button
+            onClick={goToPrevPage}
+            className={cx(
+              'dashboard-list-container-footer-pagination-container-button-left'
+            )}
+          >
+            <Image src={arrowRight.url} alt={arrowRight.alt} width={16} height={16} />
+          </button>
+          <button
+            onClick={goToNextPage}
+            className={cx(
+              'dashboard-list-container-footer-pagination-container-button-right'
+            )}
+          >
+            <Image src={arrowLeft.url} alt={arrowLeft.alt} width={16} height={16} />
+          </button>
+        </div>
+      </footer>
+    </div>
+  );
+};
+export default DashboardList;

--- a/src/components/dashboard/modal/dashboard/CreateDashboard.jsx
+++ b/src/components/dashboard/modal/dashboard/CreateDashboard.jsx
@@ -15,7 +15,7 @@ import styles from './CreateDashboard.module.scss';
 const cx = classNames.bind(styles);
 const { colorize } = ICON;
 
-function CreateDashboard({ closeModal }) {
+function CreateDashboard({ isModalOpen, toggleModal }) {
   const { handleSubmit } = useFormContext();
   const { isOpen, popupRef, buttonRef, openPopup, closePopup } = useTogglePopup();
   const { color, setColor, firstButtonRef, inputValue, handleOnChange } =
@@ -25,11 +25,16 @@ function CreateDashboard({ closeModal }) {
 
   const onSubmit = async (data) => {
     data.color = color;
-    Dashboard.create(data);
+    await Dashboard.create(data);
+    toggleModal('createDashboard');
   };
 
   return (
-    <CommonModal isModalOpen={true} label='Create Board' closeModal={closeModal}>
+    <CommonModal
+      isModalOpen={isModalOpen}
+      closeModal={() => toggleModal('createDashboard')}
+      label='Create Board'
+    >
       <form className={cx('form')} onSubmit={handleSubmit(onSubmit)}>
         <div className={cx('modal-container')}>
           <div className={cx('modal-container-thumbnail-container')}>
@@ -125,7 +130,12 @@ function CreateDashboard({ closeModal }) {
 
         <div className={cx('button-container')}>
           <div className={cx('button-container-button')}>
-            <BaseButton size='xl' text='Cancel' variant='outline'></BaseButton>
+            <BaseButton
+              onClick={() => toggleModal('createDashboard')}
+              variant='outline'
+              text='Cancel'
+              size='xl'
+            ></BaseButton>
           </div>
           <div className={cx('button-container-button')}>
             <BaseButton

--- a/src/components/dashboard/modal/dashboard/CreateDashboard.module.scss
+++ b/src/components/dashboard/modal/dashboard/CreateDashboard.module.scss
@@ -78,7 +78,7 @@
     }
 
     &-color-palette-container {
-      @include flexbox($jc: between);
+      @include flexbox(between);
 
       width: 100%;
 

--- a/src/hooks/useDashboardList.js
+++ b/src/hooks/useDashboardList.js
@@ -1,0 +1,153 @@
+import { useEffect, useState } from 'react';
+
+const useDashboardList = (dashboardData) => {
+  const dashboards = dashboardData.dashboards;
+  const totalCount = dashboardData.totalCount;
+  const ITEMS_PER_PAGE = 16;
+
+  const [itemsPerPage, setItemsPerPage] = useState(ITEMS_PER_PAGE);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [currentPageData, setCurrentPageData] = useState([]);
+  const [currentSortedData, setCurrentSortedData] = useState(null);
+  const [currentFilter, setCurrentFilter] = useState('All');
+  const [totalItems, setTotalItems] = useState(totalCount);
+  const [totalPages, setTotalPages] = useState(Math.ceil(totalItems / ITEMS_PER_PAGE));
+
+  const sortByLatest = () => {
+    if (currentSortedData) {
+      currentSortedData.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
+      renderData(currentSortedData, itemsPerPage);
+      return;
+    } else {
+      dashboards.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
+      renderData(dashboards, itemsPerPage);
+    }
+  };
+
+  const sortByEarliest = () => {
+    if (currentSortedData) {
+      currentSortedData.sort((a, b) => new Date(a.createdAt) - new Date(b.createdAt));
+      renderData(currentSortedData, itemsPerPage);
+      return;
+    } else {
+      dashboards.sort((a, b) => new Date(a.createdAt) - new Date(b.createdAt));
+      renderData(dashboards, itemsPerPage);
+    }
+  };
+
+  const goToPrevPage = () => {
+    if (currentPage > 1) {
+      setCurrentPage((prev) => prev - 1);
+    }
+  };
+
+  const goToNextPage = () => {
+    if (currentPage < totalPages) {
+      setCurrentPage((prev) => prev + 1);
+    }
+  };
+
+  const renderData = (filteredData, itemsPerPage) => {
+    const START_INDEX = (currentPage - 1) * itemsPerPage;
+    const END_INDEX = START_INDEX + itemsPerPage;
+    const currentPageData = filteredData.slice(START_INDEX, END_INDEX);
+    setCurrentPageData(currentPageData);
+  };
+
+  const handleFilterClick = (filter) => {
+    setCurrentPage(1);
+    setCurrentFilter(filter);
+    let filteredData;
+
+    switch (filter) {
+      case 'All':
+        filteredData = dashboards;
+        break;
+      case 'My Dashboard':
+        filteredData = dashboards.filter((dashboard) => dashboard.createdByMe);
+        break;
+      case 'Invited Dashboard':
+        filteredData = dashboards.filter((dashboard) => !dashboard.createdByMe);
+        break;
+      default:
+        break;
+    }
+    setCurrentSortedData(filteredData);
+    setTotalItems(filteredData.length);
+    setCurrentPageData(filteredData);
+  };
+
+  const handleDropdownClick = (value) => {
+    setCurrentPage(1);
+    if (value === 'Latest') {
+      sortByLatest();
+    } else if (value === 'Earliest') {
+      sortByEarliest();
+    }
+  };
+
+  useEffect(() => {
+    setTotalPages(Math.ceil(totalItems / itemsPerPage));
+  }, [totalItems, itemsPerPage]);
+
+  useEffect(() => {
+    setTotalItems(dashboardData.totalCount);
+  }, [dashboardData]);
+
+  useEffect(() => {
+    if (currentSortedData) {
+      renderData(currentSortedData, itemsPerPage);
+    } else {
+      renderData(dashboards, itemsPerPage);
+    }
+  }, [currentPage, dashboards, currentSortedData]);
+
+  useEffect(() => {
+    const renderDataBasedOnWindowSize = () => {
+      const currentWindowSize = window.innerWidth;
+
+      let newItemsPerPage;
+
+      if (currentWindowSize <= 767) {
+        newItemsPerPage = 1000;
+      } else if (currentWindowSize <= 1199) {
+        newItemsPerPage = 10;
+      } else if (currentWindowSize <= 1399) {
+        newItemsPerPage = 12;
+      } else {
+        newItemsPerPage = ITEMS_PER_PAGE;
+      }
+
+      if (itemsPerPage !== newItemsPerPage) {
+        setItemsPerPage(newItemsPerPage);
+        renderData(currentSortedData || dashboards, newItemsPerPage);
+      }
+    };
+
+    const handleResize = () => {
+      renderDataBasedOnWindowSize();
+    };
+
+    handleResize();
+
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, [itemsPerPage, currentSortedData, dashboards]);
+
+  return {
+    itemsPerPage,
+    currentPageData,
+    currentFilter,
+    handleFilterClick,
+    handleDropdownClick,
+    currentPage,
+    totalPages,
+    goToPrevPage,
+    goToNextPage,
+  };
+};
+
+export default useDashboardList;

--- a/src/styles/mixins/_responsive.scss
+++ b/src/styles/mixins/_responsive.scss
@@ -1,4 +1,10 @@
 @mixin responsive($screen) {
+  @if $screen == 'MP' {
+    @media screen and (max-width: $mid-pc-breakpoint) {
+      @content;
+    }
+  }
+
   @if $screen == 'T' {
     @media screen and (max-width: $tablet-breakpoint) {
       @content;

--- a/src/styles/variables/_box-shadow.scss
+++ b/src/styles/variables/_box-shadow.scss
@@ -1,2 +1,3 @@
 $modal-shadow: 0 16px 32px 0 rgba(5 5 5 / 80%);
 $dropdown-shadow: 0 4px 12px 0 rgba(0 0 0 / 32%);
+$dashboard-shadow: 0 1.6rem 3.2rem 0 rgba(0 0 0 / 32%);

--- a/src/styles/variables/_breakpoint.scss
+++ b/src/styles/variables/_breakpoint.scss
@@ -1,2 +1,3 @@
+$mid-pc-breakpoint: 1399px;
 $tablet-breakpoint: 1199px;
 $mobile-breakpoint: 767px;


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이 PR은 어떤 유형인가요?

- [x] 리팩터링
- [x] 기능
- [ ] 버그 수정
- [ ] 최적화
- [ ] 문서 업데이트

## 설명

### DashboardCard
- DashboardList 대시보드 홈페이지의 대시보드 리스트의 카드 하나를 구성하는 컴포넌트 입니다.
- hover시 border 및 애니메이션 있습니다.
- 현재는 prop으로 member와 dashboard 데이터를 받습니다. 
- dashboard의 createdByMe가 true일 때만 avatar 컴포넌트를 이용해 profileImage를 보여주고, 없다면 이름으로 프로필사진을 만들어 보여줍니다.
- header 연결 시 member 데이터를 store에서 가져올 예정입니다.

### DashboardList
- DashboardCard를 grid로 보여줍니다.
- 대시보드 홈페이지의 메인 컴포넌트 입니다.
- mid-pc, tablet, mobile 반응형 구현하였습니다.
- 화면 크기 별로 보여주는 grid column의 개수가 달라집니다. (4->3->2->1)
- pagination 기능이 있고, 모바일일 때는 페이지네이션 없이 스크롤로 보여줍니다.
- Latest, Earliest 드롭다운 필터 기능
- All, My Dashboard, Invited Dashboard 필터 기능

### 반응형

#### 모바일
<img width="812" alt="image" src="https://github.com/TickyTocky/TickyTocky/assets/92169354/ba0fb4d6-a2e7-4098-b337-aeaaf69999d0">

#### 태블릿
<img width="923" alt="image" src="https://github.com/TickyTocky/TickyTocky/assets/92169354/50aef72d-3212-4dd6-b444-defec8c9e84e">

#### mid-pc, pc
<img width="860" alt="image" src="https://github.com/TickyTocky/TickyTocky/assets/92169354/2e0fcde2-1a54-4c7f-b9c6-3e42a0fe68c2">

<!--
풀 리퀘스트가 관련되거나 문제를 해결하는 경우, 아래에 포함해 주세요. [Github의 문제 연결 가이드](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)를 따르고 싶습니다.).

예를 들어, "closes #1234"라는 텍스트가 현재 풀 리퀘스트와 1234번 이슈를 연결하고, 풀 리퀘스트가 병합되면 Github가 자동으로 이슈를 닫습니다.
-->

- Related Issue #94 
- Closes #94 

