### PR TITLE
[24-02-10 유미정] 프로필 모달에 로그아웃 기능 추가, 대시보드 편집 페이지 레이아웃 수정

### DIFF
--- a/src/components/cards/CardItem/index.jsx
+++ b/src/components/cards/CardItem/index.jsx
@@ -82,7 +82,7 @@ const CardItem = ({ columnId, id, columnName }) => {
             <span className={cx('card-footer-deadline-date')}>{dueDate}</span>
           </div>
           <Avatar
-            profileImage={assignee.profileImage}
+            profileImage={assignee.profileImageUrl}
             profileName={assignee.nickname}
             avatarSize='sm'
           />

--- a/src/components/common/ProfileModal/index.jsx
+++ b/src/components/common/ProfileModal/index.jsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import classNames from 'classnames/bind';
+import Auth from '@/api/auth';
 import Avatar from '@/components/common/Avatar';
 import BaseButton from '@/components/common/button/BaseButton';
 import styles from './ProfileModal.module.scss';
@@ -17,7 +18,9 @@ const ProfileModal = ({ profileName, profileImage, profileEmail }) => (
       <Link className={cx('link')} href={'/mypage'}>
         <BaseButton size='xl' variant='outline' type='button' text='My Page' />
       </Link>
-      <BaseButton size='xl' variant='ghost' type='button' text='Logout' />
+      <div className={cx('link')} onClick={() => Auth.logout()}>
+        <BaseButton size='xl' variant='ghost' type='button' text='Logout' />
+      </div>
     </div>
   </div>
 );

--- a/src/components/layout/Header/BoardHeader.jsx
+++ b/src/components/layout/Header/BoardHeader.jsx
@@ -23,7 +23,7 @@ const BoardHeader = ({ dashBoardId }) => {
 
   return (
     <div className={cx('container')}>
-      <Link href={`/mypage/${id}/edit`}>
+      <Link href={`/dashboard/${id}/edit`}>
         <MixButton
           svg={settings.url}
           alt={settings.alt}

--- a/src/components/layout/Layouts/MainLayout.module.scss
+++ b/src/components/layout/Layouts/MainLayout.module.scss
@@ -16,7 +16,7 @@
     }
 
     .main {
-      @include column-flexbox($ai: between);
+      @include column-flexbox($jc: start, $ai: between);
       @include responsive(M) {
         @include column-flexbox($ai: stretch);
 

--- a/src/pages/dashboard/[id]/edit/DashboardEditPage.module.scss
+++ b/src/pages/dashboard/[id]/edit/DashboardEditPage.module.scss
@@ -1,13 +1,12 @@
 .container {
   @include flexbox(start, start, 6.4rem);
 
-  padding: 4rem;
+  padding: 3.6rem 4rem;
 
   @include responsive(T) {
     @include column-flexbox(start, start, 4rem);
+    @include no-scrollbar;
 
-    padding: 3.6rem 4rem;
-    height: 100vh;
     overflow-y: scroll;
   }
 

--- a/src/pages/dashboard/[id]/edit/index.jsx
+++ b/src/pages/dashboard/[id]/edit/index.jsx
@@ -4,6 +4,7 @@ import DashboardInvitations from '@/components/dashboard/dashboardEdit/Dashboard
 import DashboardTitle from '@/components/dashboard/dashboardEdit/DashboardTitle';
 import DashboardMembers from '@/components/dashboard/dashboardEdit/DashboardMembers';
 import MainLayout from '@/components/layout/Layouts/MainLayout';
+import BoardHeader from '@/components/layout/Header/BoardHeader';
 import styles from './DashboardEditPage.module.scss';
 
 const cx = classNames.bind(styles);
@@ -15,15 +16,18 @@ const DashboardEditPage = () => {
   if (!id) return;
 
   return (
-    <div className={cx('container')}>
-      <div className={cx('container-title-members')}>
-        <DashboardTitle dashboardId={id} />
-        <DashboardMembers dashboardId={id} />
+    <>
+      <BoardHeader />
+      <div className={cx('container')}>
+        <div className={cx('container-title-members')}>
+          <DashboardTitle dashboardId={id} />
+          <DashboardMembers dashboardId={id} />
+        </div>
+        <div className={cx('container-invitations')}>
+          <DashboardInvitations dashboardId={id} />
+        </div>
       </div>
-      <div className={cx('container-invitations')}>
-        <DashboardInvitations dashboardId={id} />
-      </div>
-    </div>
+    </>
   );
 };
 


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이 PR은 어떤 유형인가요?

- [ ] 리팩터링
- [x] 기능
- [ ] 버그 수정
- [ ] 최적화
- [ ] 문서 업데이트

## 설명

1. MyHeader의 profile modal에 로그아웃 기능 추가했습니다.
2. DashboardEditPage의 레이아웃 수정하였습니다.


## 스크린샷, 녹화

![image](https://github.com/TickyTocky/TickyTocky/assets/96277798/c19d8147-cc79-466b-9481-c42d33fad116)

