### PR TITLE
[24-02-10 김희수] Textarea 글자수 제한 및 coloumn 타이틀 인풋 prop 지정

### DIFF
--- a/src/components/common/InputField/index.jsx
+++ b/src/components/common/InputField/index.jsx
@@ -49,6 +49,7 @@ const InputField = ({
               required: isRequired ? 'This is Required.' : errorMessage?.empty,
             })}
             className={cx('textarea', { empty: isRequired && isError })}
+            maxLength={255}
           ></textarea>
         ) : (
           <input

--- a/src/components/common/TextField/index.jsx
+++ b/src/components/common/TextField/index.jsx
@@ -43,6 +43,7 @@ const TextField = ({ cardId, columnId, dashboardId, name, ...props }) => {
           },
         })}
         {...props}
+        maxLength={255}
         className={cx('comment-textarea')}
       ></textarea>
       <div className={cx('comment-footer')}>

--- a/src/components/common/TextField/index.jsx
+++ b/src/components/common/TextField/index.jsx
@@ -28,8 +28,8 @@ const TextField = ({ cardId, columnId, dashboardId, name, ...props }) => {
     };
 
     await Comment.create(submitData);
+    reset({ content: '' });
     await Comment.getList(cardId);
-    reset();
   };
 
   return (

--- a/src/components/dashboard/modal/card/CreateCard.jsx
+++ b/src/components/dashboard/modal/card/CreateCard.jsx
@@ -158,7 +158,7 @@ const CreateCard = ({
               name='title'
               type='text'
               defaultValue={isEdit ? title : ''}
-              maxLength={11}
+              maxLength={15}
               isRequired
             />
             <InputField

--- a/src/components/dashboard/modal/column/AddColumn.jsx
+++ b/src/components/dashboard/modal/column/AddColumn.jsx
@@ -29,6 +29,7 @@ const AddColumn = ({ closeModal, dashBoardId }) => {
           type='text'
           placeholder='Enter the title'
           maxLength={MAX_TEXT_LENGTH}
+          isRequired
         />
         <div className={cx('button', 'button-top')}>
           <div onClick={closeModal}>


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이 PR은 어떤 유형인가요?

- [x] 리팩터링
- [ ] 기능
- [ ] 버그 수정
- [ ] 최적화
- [ ] 문서 업데이트

## 설명
- textarea 글자 수 255자 제한
- comment 작성 후 남아있는 value 삭제
- column 타이틀 모달 isRequired props 적용 -> 필수 요소로 지정 -> 한 글자도 입력하지 않을 경우 error 보여줌