### PR TITLE
[24-02-11 유미정] 초대 팝업 추가, 대시보드 데이터 받아오는 훅 생성, 대시보드 생성자 구분

### DIFF
--- a/src/components/HeaderButtons/index.jsx
+++ b/src/components/HeaderButtons/index.jsx
@@ -2,7 +2,8 @@ import Link from 'next/link';
 import Image from 'next/image';
 import classNames from 'classnames/bind';
 import IconButton from '@/components/common/button/IconButton';
-import useTogglePopup from '@/hooks/useTogglePopup';
+import InvitationPopUp from '@/components/invitations/InvitationPopUp';
+import useModalTogglePopup from '@/hooks/useModalTogglePopup';
 import { ICON } from '@/constants/importImage';
 import styles from './HeaderButtons.module.scss';
 
@@ -10,7 +11,7 @@ const cx = classNames.bind(styles);
 const { home, email } = ICON;
 
 const HeaderButtons = () => {
-  const { isOpen, popupRef, buttonRef, openPopup, closePopup } = useTogglePopup();
+  const { isOpen, popupRef, buttonRef, openPopup, closePopup } = useModalTogglePopup();
 
   return (
     <>
@@ -26,7 +27,7 @@ const HeaderButtons = () => {
       </button>
       {isOpen && (
         <div className={cx('popup')} ref={popupRef}>
-          초대 팝업
+          <InvitationPopUp />
         </div>
       )}
     </>

--- a/src/components/dashboard/modal/column/EditColumn.jsx
+++ b/src/components/dashboard/modal/column/EditColumn.jsx
@@ -31,6 +31,7 @@ const EditColumn = ({ dashboardId, columnId, title, closeModal }) => {
           placeholder='Enter the title'
           defaultValue={title}
           maxLength={MAX_TEXT_LENGTH}
+          isRequired
         />
         <div className={cx('button', 'button-top')}>
           <div onClick={closeModal}>

--- a/src/components/invitations/InvitationItem/index.jsx
+++ b/src/components/invitations/InvitationItem/index.jsx
@@ -95,7 +95,7 @@ const InvitationItem = ({ id, title, name, HandleRefreshInvitations }) => {
           closeModal={handleToggleDenyModal}
           iconSize={58}
           title='Invitation Decline'
-          desc='Are you sure you want to decline this invitation?'
+          desc='Are you sure you want to decline?'
           iconName={ICON.remove}
         >
           <div className={cx('modal-buttons')}>

--- a/src/components/layout/Header/BoardHeader.jsx
+++ b/src/components/layout/Header/BoardHeader.jsx
@@ -1,9 +1,8 @@
-import { useRouter } from 'next/router';
 import Link from 'next/link';
+import Image from 'next/image';
 import classNames from 'classnames/bind';
 import Dashboard from '@/api/dashboards';
 import InvitationMembers from '@/components/common/InvitationMembers';
-import MixButton from '@/components/common/button/MixButton';
 import Breadcrumb from '@/components/common/Breadcrumb';
 import useDashBoardStore from '@/stores/useDashboardStore';
 import useAsync from '@/hooks/useAsync';
@@ -15,28 +14,21 @@ const cx = classNames.bind(styles);
 const { settings } = ICON;
 
 const BoardHeader = ({ dashBoardId }) => {
-  const router = useRouter();
-  const { id } = router.query;
-
-  useAsync(() => Dashboard.get(Number(dashBoardId)), INIT_DASHBOARD_DATA);
+  useAsync(() => Dashboard.get(dashBoardId), INIT_DASHBOARD_DATA);
   const { dashboard } = useDashBoardStore();
 
   return (
     <div className={cx('container')}>
-      <Link href={`/dashboard/${id}/edit`}>
-        <MixButton
-          svg={settings.url}
-          alt={settings.alt}
-          reverse
-          size={24}
-          type='button'
-          gap={4}
-          text={dashboard?.title}
-          fontSize={24}
-        />
-      </Link>
+      <div className={cx('title')}>
+        <span className={cx('title-text')}>{dashboard?.title}</span>
+        {dashboard?.createdByMe && (
+          <Link className={cx('title-link')} href={`/dashboard/${dashBoardId}/edit`}>
+            <Image src={settings.url} alt={settings.alt} width={24} height={24} />
+          </Link>
+        )}
+      </div>
       <div className={cx('info-wrap')}>
-        <InvitationMembers dashBoardId={Number(dashBoardId)} />
+        <InvitationMembers dashBoardId={dashBoardId} />
         <div className={cx('line')}></div>
         <Breadcrumb title={dashboard?.title} />
       </div>

--- a/src/components/layout/Header/BoardHeader.module.scss
+++ b/src/components/layout/Header/BoardHeader.module.scss
@@ -14,6 +14,18 @@
   }
 }
 
+.title {
+  @include flexbox($gap: 0.4rem);
+
+  &-text {
+    @include text-style(24, $white, bold);
+  }
+
+  &-link {
+    line-height: 0;
+  }
+}
+
 .info-wrap {
   @include flexbox($gap: 1.6rem);
 }

--- a/src/hooks/useDashboardFetchData.js
+++ b/src/hooks/useDashboardFetchData.js
@@ -1,0 +1,23 @@
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
+import Columns from '@/api/columns';
+import Dashboard from '@/api/dashboards';
+
+const useDashboardFetchData = () => {
+  const router = useRouter();
+  const { id } = router.query;
+
+  useEffect(() => {
+    const fetchData = async () => {
+      if (router.isReady) {
+        await Columns.getList(Number(id));
+        await Dashboard.get(Number(id));
+      }
+    };
+    fetchData();
+  }, [router.isReady, id]);
+
+  return { id };
+};
+
+export default useDashboardFetchData;

--- a/src/hooks/useModalTogglePopup.js
+++ b/src/hooks/useModalTogglePopup.js
@@ -1,0 +1,45 @@
+import { useEffect, useRef, useState } from 'react';
+
+function useModalTogglePopup() {
+  const [isOpen, setIsOpen] = useState(false);
+  const popupRef = useRef(null);
+  const buttonRef = useRef(null);
+
+  useEffect(() => {
+    const handleClickOutside = (event) => {
+      const element = document.querySelector('.ReactModal__Content');
+      if (element) return;
+      if (
+        isOpen &&
+        popupRef.current &&
+        !popupRef.current.contains(event.target) &&
+        buttonRef.current &&
+        !buttonRef.current.contains(event.target)
+      ) {
+        setIsOpen(false);
+      }
+    };
+
+    if (isOpen) {
+      window.addEventListener('mousedown', handleClickOutside);
+    } else {
+      window.removeEventListener('mousedown', handleClickOutside);
+    }
+
+    return () => {
+      window.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [isOpen]);
+
+  const openPopup = () => {
+    setIsOpen(true);
+  };
+
+  const closePopup = () => {
+    setIsOpen(false);
+  };
+
+  return { isOpen, popupRef, buttonRef, openPopup, closePopup };
+}
+
+export default useModalTogglePopup;

--- a/src/pages/dashboard/[id]/index.jsx
+++ b/src/pages/dashboard/[id]/index.jsx
@@ -1,11 +1,10 @@
-import { useRouter } from 'next/router';
 import MainLayout from '@/components/layout/Layouts/MainLayout';
 import BoardHeader from '@/components/layout/Header/BoardHeader';
 import ColumnLayout from '@/components/layout/dashboard/Column';
+import useDashboardFetchData from '@/hooks/useDashboardFetchData';
 
 const DashboardPage = () => {
-  const router = useRouter();
-  const { id } = router.query;
+  const { id } = useDashboardFetchData();
 
   if (id === undefined) return;
 


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이 PR은 어떤 유형인가요?

- [ ] 리팩터링
- [x] 기능
- [ ] 버그 수정
- [ ] 최적화
- [ ] 문서 업데이트

## 설명
**1.** 초대 팝업
- 초대 팝업에서 기능 버튼 클릭 시 모달이 뜨는데 그때 모달을 클릭하면 팝업이 닫혀버리면서 데이터 전달이 안되는 이슈가 있었습니다.
- 기존 useTogglePopup을 사용하려고 했지만 추가할 부분이 많아 따로 useModalTogglePopup hook을 만들었습니다.

**2.** 대시보드 데이터를 DashboardPage에서 계속 받아야 돼서 따로 useDashboardFetchData hook을 만들었습니다.

**3.** 대시보드 편집 버튼
- 대시보드 편집 버튼이 원래 title과 같이 컴포넌트로 묶여 있었는데 컴포넌트 사용하지 않고 버튼을 만들었습니다.
- 버튼은 본인이 만든 대시보드가 아니면 보이지 않습니다.



## 스크린샷, 녹화

![image](https://github.com/TickyTocky/TickyTocky/assets/96277798/6261bf43-5587-4f9a-9ea5-dcff9413a087)

