### PR TITLE
[24-02-11 김희수] Dashboard 모바일 반응형, Nav padding 수정 

### DIFF
--- a/src/components/dashboard/DashboardCard/DashboardCard.module.scss
+++ b/src/components/dashboard/DashboardCard/DashboardCard.module.scss
@@ -9,6 +9,23 @@
   border: 0.1rem solid rgba(0 0 0 / 0%);
   transition: all ease-in-out 0.3s;
 
+  &:hover {
+    cursor: pointer;
+    border: 0.1rem solid transparent;
+    transform: translateY(-1rem);
+  }
+
+  @include responsive(M) {
+    min-width: 100%;
+    width: 100%;
+
+    &:hover {
+      pointer-events: none;
+      border: hidden;
+      transform: translateY(0);
+    }
+  }
+
   &-side-pointer {
     @include pos-center-y;
 
@@ -18,12 +35,6 @@
     border-radius: 0 0.8rem 0.8rem 0;
     background: $primary;
     z-index: $modal-level;
-  }
-
-  &:hover {
-    cursor: pointer;
-    border: 0.1rem solid transparent;
-    transform: translateY(-1rem);
   }
 
   &-container {

--- a/src/components/dashboard/DashboardList/DashboardList.module.scss
+++ b/src/components/dashboard/DashboardList/DashboardList.module.scss
@@ -1,8 +1,10 @@
 .dashboard-list-container {
-  @include column-flexbox(center, start, 2.4rem);
+  @include column-flexbox(start, start, 2.4rem);
 
-  margin: 12.6rem auto;
+  height: 100%;
   min-width: 136rem;
+  padding-top: 5.6rem;
+  margin: 0 auto;
 
   @include responsive(MP) {
     min-width: 101.4rem;
@@ -10,18 +12,24 @@
 
   @include responsive(T) {
     min-width: 66.8rem;
+    padding: 2.4rem 0;
   }
 
   @include responsive(M) {
     @include no-scrollbar;
 
-    overflow-y: scroll;
+    gap: 1.6rem;
     width: 100%;
-    padding: 0 1.5rem;
+    min-width: 100%;
+    padding: 2.4rem 0 1.5rem;
   }
 
   &-header {
     @include flexbox(start, center, 1.6rem);
+
+    @include responsive(M) {
+      padding: 0 1.5rem;
+    }
 
     &-container {
       @include flexbox($gap: 0.8rem);
@@ -62,6 +70,7 @@
     @include responsive(M) {
       width: 100%;
       height: auto;
+      gap: 2.4rem;
       align-items: center;
     }
 
@@ -84,6 +93,7 @@
 
           width: 100%;
           overflow-x: scroll;
+          padding: 0 1.5rem;
         }
 
         .all,
@@ -119,6 +129,7 @@
 
         @include responsive(M) {
           width: 100%;
+          padding: 0 1.5rem;
           justify-content: space-between;
           flex-direction: row-reverse;
         }
@@ -159,8 +170,8 @@
         @include no-scrollbar;
 
         width: 100%;
-        padding-top: 1.2rem;
         grid-template-columns: repeat(1, auto);
+        padding: 0 1.5rem;
         overflow-x: hidden;
       }
     }

--- a/src/components/layout/Layouts/MainLayout.module.scss
+++ b/src/components/layout/Layouts/MainLayout.module.scss
@@ -17,17 +17,19 @@
 
     .main {
       @include column-flexbox($jc: start, $ai: between);
-      @include responsive(M) {
-        @include column-flexbox($ai: stretch);
-
-        width: 100%;
-        height: calc(100vh - 7rem - 7.2rem);
-      }
 
       width: 100%;
       height: 100%;
       overflow: hidden;
       overflow-x: auto;
+
+      @include responsive(M) {
+        @include column-flexbox(start, stretch);
+
+        width: 100%;
+        height: calc(100vh - 7rem - 7.2rem);
+        overflow-x: hidden;
+      }
     }
   }
 }

--- a/src/components/layout/Nav/Nav.module.scss
+++ b/src/components/layout/Nav/Nav.module.scss
@@ -14,7 +14,7 @@
     flex-direction: row;
     width: 100%;
     height: 7.2rem;
-    padding: 0;
+    padding: 0 1.5rem;
     background-color: $gray90;
     border-bottom: 0.1rem solid $gray70;
     overflow-x: auto;
@@ -30,7 +30,7 @@
 
       flex-direction: row;
       height: 7.2rem;
-      padding: 0 1.5rem;
+      padding: 0 1.6rem 0 0;
     }
 
     .divider {


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이 PR은 어떤 유형인가요?

- [x] 리팩터링
- [ ] 기능
- [ ] 버그 수정
- [ ] 최적화
- [ ] 문서 업데이트

## 설명
- 대시보드 모바일 반응형 적용했습니다.
- 네비게이션 양 옆 padding 조정했습니다.

## 스크린샷, 녹화

<img width="367" alt="스크린샷 2024-02-11 오전 4 17 02" src="https://github.com/TickyTocky/TickyTocky/assets/77719310/fedbf205-d9c2-416d-82fd-996341c7b073">

<img width="365" alt="스크린샷 2024-02-11 오전 4 16 49" src="https://github.com/TickyTocky/TickyTocky/assets/77719310/7a8f3b34-d1e8-4c50-9ab0-d5c6944fa9d7">
