### PR TITLE
[24-02-11 김희수] 모달 버튼 반응형 크기 적용, importimage 이미지 추가, maxLength 수정

### DIFF
--- a/src/components/auth/common/FormHeader.jsx
+++ b/src/components/auth/common/FormHeader.jsx
@@ -1,30 +1,28 @@
 import Image from 'next/image';
 import Link from 'next/link';
 import classNames from 'classnames/bind';
-import { ICON } from '@/constants';
+import { ICON } from '@/constants/importImage';
 import styles from './FormHeader.module.scss';
 
 const cx = classNames.bind(styles);
 const { logo } = ICON;
 
-const FormHeader = () => {
-  return (
-    <header className={cx('login-header')}>
-      <h1 className={cx('login-header-title')}>
-        <Link href={'/'}>
-          <Image
-            src={logo.url}
-            alt={logo.alt}
-            width={257}
-            height={40}
-            priority={true}
-            as='image'
-          ></Image>
-        </Link>
-      </h1>
-      <p className={cx('login-header-desc')}>Manage your projects more powerful</p>
-    </header>
-  );
-};
+const FormHeader = () => (
+  <header className={cx('login-header')}>
+    <h1 className={cx('login-header-title')}>
+      <Link href={'/'}>
+        <Image
+          src={logo.url}
+          alt={logo.alt}
+          width={257}
+          height={40}
+          priority={true}
+          as='image'
+        ></Image>
+      </Link>
+    </h1>
+    <p className={cx('login-header-desc')}>Manage your projects more powerful</p>
+  </header>
+);
 
 export default FormHeader;

--- a/src/components/common/InputField/index.jsx
+++ b/src/components/common/InputField/index.jsx
@@ -49,7 +49,7 @@ const InputField = ({
               required: isRequired ? 'This is Required.' : errorMessage?.empty,
             })}
             className={cx('textarea', { empty: isRequired && isError })}
-            maxLength={255}
+            maxLength={245}
           ></textarea>
         ) : (
           <input

--- a/src/components/common/TextField/index.jsx
+++ b/src/components/common/TextField/index.jsx
@@ -3,7 +3,7 @@ import classNames from 'classnames/bind';
 import Comment from '@/api/comments';
 import IconButton from '@/components/common/button/IconButton';
 import BaseButton from '@/components/common/button/BaseButton';
-import { ICON } from '@/constants';
+import { ICON } from '@/constants/importImage';
 import styles from './TextField.module.scss';
 
 const cx = classNames.bind(styles);
@@ -43,7 +43,7 @@ const TextField = ({ cardId, columnId, dashboardId, name, ...props }) => {
           },
         })}
         {...props}
-        maxLength={255}
+        maxLength={245}
         className={cx('comment-textarea')}
       ></textarea>
       <div className={cx('comment-footer')}>

--- a/src/components/dashboard/modal/card/CreateCard.jsx
+++ b/src/components/dashboard/modal/card/CreateCard.jsx
@@ -203,7 +203,7 @@ const CreateCard = ({
           <BaseButton
             variant='outline'
             size='xl'
-            text='close'
+            text='Close'
             onClick={handleModalClose}
           />
         </div>

--- a/src/components/dashboard/modal/card/CreateCard.jsx
+++ b/src/components/dashboard/modal/card/CreateCard.jsx
@@ -179,15 +179,15 @@ const CreateCard = ({
         <div className={cx('field-submit')}>
           <BaseButton
             type='button'
-            size='lg'
+            size='xl'
             variant='outline'
             text='Cancel'
             onClick={handleModalClose}
           />
           {isEdit ? (
-            <BaseButton type='submit' size='lg' variant='secondary' text='Apply' />
+            <BaseButton type='submit' size='xl' variant='secondary' text='Apply' />
           ) : (
-            <BaseButton type='submit' size='lg' variant='secondary' text='Create' />
+            <BaseButton type='submit' size='xl' variant='secondary' text='Create' />
           )}
         </div>
       </form>

--- a/src/components/dashboard/modal/card/CreateCard.module.scss
+++ b/src/components/dashboard/modal/card/CreateCard.module.scss
@@ -128,6 +128,12 @@
 
     &-submit {
       @include flexbox($gap: 1.2rem);
+
+      width: 25.2rem;
+
+      @include responsive(M) {
+        width: 100%;
+      }
     }
   }
 }

--- a/src/components/dashboard/modal/card/DetailCard.jsx
+++ b/src/components/dashboard/modal/card/DetailCard.jsx
@@ -87,12 +87,14 @@ const DetailCard = ({ colId, cardId, toggleModal }) => {
       </div>
 
       <div className={cx('button-content')}>
-        <BaseButton
-          size='lg'
-          variant='outline'
-          text='Cancel'
-          onClick={handleModalClose}
-        />
+        <div className={cx('button-content-inner')}>
+          <BaseButton
+            size='xl'
+            variant='outline'
+            text='Cancel'
+            onClick={handleModalClose}
+          />
+        </div>
       </div>
     </div>
   );

--- a/src/components/dashboard/modal/card/DetailCard.module.scss
+++ b/src/components/dashboard/modal/card/DetailCard.module.scss
@@ -1,5 +1,5 @@
 .container {
-  @include column-flexbox(start, start, 1.6rem);
+  @include column-flexbox(start, end, 1.6rem);
 
   width: 100%;
 
@@ -206,13 +206,19 @@
   }
 
   .button-content {
+    @include flexbox(end);
+
     width: 100%;
     padding-top: 2.4rem;
     border-top: 0.1rem solid $gray70;
     text-align: right;
 
-    @include responsive(M) {
-      border: none;
+    &-inner {
+      width: 12rem;
+
+      @include responsive(M) {
+        width: 100%;
+      }
     }
   }
 }

--- a/src/components/layout/dashboard/Column/ColumnLayout.module.scss
+++ b/src/components/layout/dashboard/Column/ColumnLayout.module.scss
@@ -6,13 +6,13 @@
   overflow-y: auto;
 
   &::-webkit-scrollbar {
-    width: 1rem;
+    height: 3rem;
   }
 
   &::-webkit-scrollbar-thumb {
     background-color: $gray40;
-    border-radius: 1rem;
-    border: 0.5rem solid $gray90;
+    border-radius: 99rem;
+    border: 1rem solid $gray90;
   }
 
   &::-webkit-scrollbar-track {

--- a/src/constants/importImage.js
+++ b/src/constants/importImage.js
@@ -28,6 +28,7 @@ import IconPageArrowLeft from 'public/svg/ic-page-arrow-left.svg';
 import IconColorize from 'public/svg/ic-colorize.svg';
 import IconSuccess from 'public/svg/ic-success.svg';
 import IconEmail from 'public/svg/ic-email.svg';
+import IconReset from 'public/svg/ic-reset.svg';
 
 export const IMAGE = {
   uploadImage: {
@@ -170,5 +171,9 @@ export const ICON = {
   email: {
     url: IconEmail,
     alt: 'icon-email',
+  },
+  reset: {
+    url: IconReset,
+    alt: 'reset-icon',
   },
 };


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이 PR은 어떤 유형인가요?

- [x] 리팩터링
- [ ] 기능
- [ ] 버그 수정
- [ ] 최적화
- [ ] 문서 업데이트

## 설명
- Text-field, Input-field maxLength 245자 변경
- 스크롤 두께 수정
- 이미지 파일 reset 등록 및 적용
- 생성, 수정 모달 버튼 모바일 크기 반응형 사이즈 xl 적용

## 스크린샷, 녹화
### 1️⃣ 버튼 반응형 적용
<img width="329" alt="image" src="https://github.com/TickyTocky/TickyTocky/assets/77719310/d3f04433-b43d-45a5-a7ff-8798d76453df">

<img width="326" alt="image" src="https://github.com/TickyTocky/TickyTocky/assets/77719310/67f54e48-4238-4550-8b5e-4120637f140c">

### 2️⃣ 하단 스크롤 두께 변경
<img width="1434" alt="image" src="https://github.com/TickyTocky/TickyTocky/assets/77719310/bafceef7-45e4-4feb-b2a8-c5fa03358b2e">
