### PR TITLE
[24-02-12 고성선] useAuth 훅 생성 및 MyHeader 컴포넌트에 사용 

### DIFF
--- a/src/components/layout/Header/MyHeader.jsx
+++ b/src/components/layout/Header/MyHeader.jsx
@@ -7,11 +7,13 @@ import HeaderButtons from '@/components/HeaderButtons';
 import useModalTogglePopup from '@/hooks/useModalTogglePopup';
 import { ICON } from '@/constants/importImage';
 import styles from './MyHeader.module.scss';
+import useAuth from '@/hooks/useAuth';
 
 const cx = classNames.bind(styles);
 const { logo } = ICON;
 
 const MyHeader = ({ user }) => {
+  useAuth();
   const { isOpen, popupRef, buttonRef, openPopup, closePopup } = useModalTogglePopup();
 
   return (

--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -1,0 +1,15 @@
+import { router } from 'next/router';
+import { useEffect } from 'react';
+import LocalStorage from '@/services/localStorage';
+
+const useAuth = () => {
+  const token = LocalStorage.getItem('accessToken');
+
+  useEffect(() => {
+    if (!token) {
+      router.push('/login');
+    }
+  }, [token]);
+};
+
+export default useAuth;

--- a/src/pages/mypage/index.jsx
+++ b/src/pages/mypage/index.jsx
@@ -1,22 +1,10 @@
-import { router } from 'next/router';
-import { useEffect } from 'react';
 import AccountList from '@/components/account';
 import MainLayout from '@/components/layout/Layouts/MainLayout';
-import LocalStorage from '@/services/localStorage';
 
-const Account = () => {
-  useEffect(() => {
-    const token = LocalStorage.getItem('accessToken');
-    if (!token) {
-      router.push('/login');
-    }
-  }, []);
-
-  return (
-    <MainLayout>
-      <AccountList />
-    </MainLayout>
-  );
-};
+const Account = () => (
+  <MainLayout>
+    <AccountList />
+  </MainLayout>
+);
 
 export default Account;


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이 PR은 어떤 유형인가요?

- [ ] 리팩터링
- [x] 기능
- [ ] 버그 수정
- [ ] 최적화
- [ ] 문서 업데이트

## 설명
인증정보 (엑세스토큰) 없을때 로그인 페이지로 리다이렉트 되게 useAuth 훅을 만들었고 MyHeader에 적용하였습니다.
mydashboard, mypage에서 인증정보가 없다면 로그인 페이지로 리다이렉트 되도록

## 관련 티켓 및 문서

<!--
풀 리퀘스트가 관련되거나 문제를 해결하는 경우, 아래에 포함해 주세요. [Github의 문제 연결 가이드](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)를 따르고 싶습니다.).

예를 들어, "closes #1234"라는 텍스트가 현재 풀 리퀘스트와 1234번 이슈를 연결하고, 풀 리퀘스트가 병합되면 Github가 자동으로 이슈를 닫습니다.
-->

- Related Issue #154 
- Closes #154 

## 스크린샷, 녹화

_변경사항을 테스트하는 방법, 테스트에 사용된 기기 및 브라우저, UI 변경에 대한 관련 이미지 등에 대한 지침을 이곳에 기재해 주세요._

### UI 접근성 체크리스트

_UI 변경 사항이 있는 경우, 이 체크리스트를 활용하세요:_
- [ ] Semantic HTML 구현?
- [ ] 키보드 조작이 지원?
- [ ] [axe DevTools](https://www.deque.com/axe/)를 사용하여 Critical 및 Serious 문제를 확인하고 해결했나요?

## [선택사항] 이 PR을 가장 잘 설명하는 GIF는 무엇인가요?
