### PR TITLE
[24-02-12 허우림] Nav 중복키 오류 해결

### DIFF
--- a/src/components/layout/Layouts/MainLayout.jsx
+++ b/src/components/layout/Layouts/MainLayout.jsx
@@ -1,29 +1,45 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import classNames from 'classnames/bind';
 import Users from '@/api/users';
 import Nav from '@/components/layout/Nav';
 import MyHeader from '@/components/layout/Header/MyHeader';
-import useUserStore from '@/stores/useUserStore';
 import useAsync from '@/hooks/useAsync';
-import { INIT_USER_DATA } from '@/constants/initialDataType';
+import useUserStore from '@/stores/useUserStore';
+import Dashboard from '@/api/dashboards';
+import { INIT_DASHBOARDS_DATA, INIT_USER_DATA } from '@/constants/initialDataType';
 import styles from './MainLayout.module.scss';
 
 const cx = classNames.bind(styles);
 
 const MainLayout = ({ children }) => {
   useAsync(() => Users.get(), INIT_USER_DATA);
+  useAsync(() => Dashboard.getList(), INIT_DASHBOARDS_DATA);
   const { user } = useUserStore();
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    const handleResize = () => {
+      if (window.innerWidth <= 768) {
+        setIsMobile(true);
+      } else {
+        setIsMobile(false);
+      }
+    };
+
+    window.addEventListener('resize', handleResize);
+    handleResize();
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
 
   return (
     <div className={cx('layout')}>
-      <div className='sm-hidden'>
-        <Nav />
-      </div>
+      <div className='sm-hidden'>{!isMobile && <Nav />}</div>
       <div className={cx('container')}>
         <MyHeader user={user} />
-        <div className={cx('sm-only', 'sm-nav')}>
-          <Nav />
-        </div>
+        <div className={cx('sm-only', 'sm-nav')}>{isMobile && <Nav />}</div>
         <main className={cx('main')}>{children}</main>
       </div>
     </div>

--- a/src/components/layout/Layouts/MainLayout.jsx
+++ b/src/components/layout/Layouts/MainLayout.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import classNames from 'classnames/bind';
 import Users from '@/api/users';
 import Nav from '@/components/layout/Nav';

--- a/src/components/layout/Nav/index.jsx
+++ b/src/components/layout/Nav/index.jsx
@@ -3,13 +3,10 @@ import classNames from 'classnames/bind';
 import ModalButton from '@/components/nav/ModalButton';
 import LinkButton from '@/components/nav/LinkButton';
 import CreateDashboard from '@/components/dashboard/modal/dashboard/CreateDashboard';
-import useAsync from '@/hooks/useAsync';
+import IconModal from '@/components/layout/modal/IconModal';
 import useModalState from '@/hooks/useModalState';
 import useDashBoardStore from '@/stores/useDashboardStore';
-import Dashboard from '@/api/dashboards';
-import IconModal from '@/components/layout/modal/IconModal';
 import Auth from '@/api/auth';
-import { INIT_DASHBOARDS_DATA } from '@/constants/initialDataType';
 import { ICON } from '@/constants/importImage';
 import styles from './Nav.module.scss';
 
@@ -18,8 +15,6 @@ const cx = classNames.bind(styles);
 const Nav = () => {
   const router = useRouter();
   const { id } = router.query;
-
-  useAsync(() => Dashboard.getList(), INIT_DASHBOARDS_DATA);
   const { dashboardList } = useDashBoardStore();
   const { modalState, toggleModal } = useModalState([
     'createDashboard',
@@ -44,9 +39,9 @@ const Nav = () => {
         </div>
         <div className={cx('home-dashboard-container')}>
           <LinkButton type='home' isHomeFocused={id ? false : true} />
-          {dashboardList?.map((board) => (
+          {dashboardList?.map((board, i) => (
             <LinkButton
-              key={`key-nav-dashboard-key-${board.id}`}
+              key={`nav-dashboard-key-${board.id}-${i}`}
               type='board'
               boardData={board}
               isBoardFocused={board.id === Number(id) ? true : false}

--- a/src/pages/mydashboard/index.jsx
+++ b/src/pages/mydashboard/index.jsx
@@ -1,12 +1,7 @@
 import DashboardList from '@/components/dashboard/DashboardList';
 import MainLayout from '@/components/layout/Layouts/MainLayout';
-import useDashBoardStore from '@/stores/useDashboardStore';
 
-const MydashboardPage = () => {
-  const { dashboardList } = useDashBoardStore();
-
-  return <DashboardList dashboardData={dashboardList} />;
-};
+const MydashboardPage = () => <DashboardList />;
 
 export default MydashboardPage;
 


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이 PR은 어떤 유형인가요?

- [ ] 리팩터링
- [ ] 기능
- [x] 버그 수정
- [ ] 최적화
- [ ] 문서 업데이트

## 설명
- Nav 중복키 오류 해결했습니다.
1. Mainlayout에서 모바일 반응형에 따라 Nav를 조건부 렌더링 했습니다.
2. Nav에서 getList 요청하는 것을 Mainlayout에서 하도록 했습니다.
3. Nav key값에 index를 추가해서 dashboardList의 아이템들이 중복 키값을 갖지 않도록 하였습니다.

## 스크린샷, 녹화

### 오류 해결 전 콘솔
<img width="1017" alt="image" src="https://github.com/TickyTocky/TickyTocky/assets/92169354/106f2311-09ee-466e-b50b-3de11f9815b2">

### 오류 해결 후 콘솔
<img width="1120" alt="image" src="https://github.com/TickyTocky/TickyTocky/assets/92169354/4ce162f2-66a4-4ed9-81b3-c51a48e6cb7e">
