### PR TITLE
[24-02-18 허우림] 모바일 대시보드 생성 모달 close 해결

### DIFF
--- a/src/components/dashboard/DashboardList/index.jsx
+++ b/src/components/dashboard/DashboardList/index.jsx
@@ -33,7 +33,7 @@ const DashboardList = () => {
     <div className={cx('dashboard-list-container')}>
       <CreateDashboard
         isModalOpen={modalState.createDashboard}
-        toggleModal={toggleModal}
+        closeModal={() => toggleModal('createDashboard')}
       />
       <header className={cx('dashboard-list-container-header')}>
         <div className={cx('dashboard-list-container-header-container')}>


### PR DESCRIPTION
## 원인
- dashboardList에서 CreateDashboard 컴포넌트에 prop이름을 closeModal이 아니라 toggleModal로 잘못 전달
- 콜백으로 함수 전달하지 않음