### PR TITLE
[24-02-20 유미정] MemberPopup 컴포넌트 구현, 버튼 텍스트 더블클릭 시 파란색 배경 제거

### DIFF
--- a/src/components/common/Avatar/Avatar.module.scss
+++ b/src/components/common/Avatar/Avatar.module.scss
@@ -8,7 +8,7 @@
 }
 
 .container {
-  @include flexbox($jc: none, $gap: 0.8rem);
+  @include flexbox($gap: 0.8rem);
 }
 
 .avatar-size {
@@ -37,16 +37,6 @@
   }
 }
 
-.text-color {
-  &-gray10 {
-    @include text-style(16, $gray10, bold);
-  }
-
-  &-gray20 {
-    @include text-style(16, $gray20);
-  }
-}
-
 .active {
   border: 0.2rem solid $primary;
 }
@@ -63,8 +53,22 @@
   background-color: $purple;
 }
 
-.text-icon-wrap {
+.info {
   @include flexbox($gap: 0.2rem);
 
   cursor: pointer;
+
+  &-text {
+    user-select: none;
+  }
+
+  &-text-color {
+    &-gray10 {
+      @include text-style(16, $gray10, bold);
+    }
+
+    &-gray20 {
+      @include text-style(16, $gray20);
+    }
+  }
 }

--- a/src/components/common/Avatar/index.jsx
+++ b/src/components/common/Avatar/index.jsx
@@ -43,8 +43,10 @@ const Avatar = ({
             )}
           </div>
           {textColor && (
-            <div className={cx('text-icon-wrap')}>
-              <span className={cx(`text-color-${textColor}`)}>{profileName}</span>
+            <div className={cx('info')}>
+              <span className={cx('info-text', `info-text-color-${textColor}`)}>
+                {profileName}
+              </span>
               {isArrow &&
                 (isOpen ? (
                   <Image

--- a/src/components/common/DropDown/DropDown.module.scss
+++ b/src/components/common/DropDown/DropDown.module.scss
@@ -23,6 +23,7 @@
     height: 100%;
     padding: 0 1.6rem;
     transition: $base-transition;
+    user-select: none;
 
     &:hover {
       cursor: pointer;

--- a/src/components/common/InvitationMembers/InvitationMembers.module.scss
+++ b/src/components/common/InvitationMembers/InvitationMembers.module.scss
@@ -12,18 +12,20 @@
 
 .members-list {
   @include flexbox;
-}
 
-.hidden-members-num {
-  @include flexbox;
-  @include text-style(12, $gray20);
+  cursor: pointer;
 
-  width: 2.8rem;
-  margin: 0 0.2rem;
-  background-color: $gray70;
-  border-radius: 50%;
-  aspect-ratio: 1;
-  box-sizing: content-box;
+  &-num {
+    @include flexbox;
+    @include text-style(12, $gray20);
+
+    width: 2.8rem;
+    margin: 0 0.2rem;
+    background-color: $gray70;
+    border-radius: 50%;
+    aspect-ratio: 1;
+    box-sizing: content-box;
+  }
 }
 
 .line {

--- a/src/components/common/InvitationMembers/index.jsx
+++ b/src/components/common/InvitationMembers/index.jsx
@@ -2,7 +2,6 @@ import classNames from 'classnames/bind';
 import Avatar from '@/components/common/Avatar';
 import MixButton from '@/components/common/button/MixButton';
 import InviteDashboard from '@/components/dashboard/modal/dashboard/InviteDashboard';
-import useGetMembers from '@/hooks/useGetMembers';
 import useModalState from '@/hooks/useModalState';
 import useInvitationMembers from '@/hooks/invitationMembers/useInvitationMembers';
 import { ICON } from '@/constants';
@@ -11,15 +10,25 @@ import styles from './InvitationMembers.module.scss';
 const cx = classNames.bind(styles);
 const { add } = ICON;
 
-const InvitationMembers = ({ dashboardId, createdByMe }) => {
-  const { memberList } = useGetMembers({ dashboardId });
-
+const InvitationMembers = ({
+  dashboardId,
+  createdByMe,
+  memberList,
+  isOpen,
+  buttonRef,
+  openPopup,
+  closePopup,
+}) => {
   const { visibleMembersNum } = useInvitationMembers();
   const { modalState, toggleModal } = useModalState(['headerInviteMember']);
 
   return (
     <div className={cx('container')}>
-      <ul className={cx('members-list')}>
+      <ul
+        className={cx('members-list')}
+        ref={buttonRef}
+        onClick={isOpen ? closePopup : openPopup}
+      >
         {memberList && memberList?.length > visibleMembersNum
           ? memberList?.slice(0, visibleMembersNum).map((member) => (
               <li key={`key-member-list-${member.id}`}>
@@ -43,7 +52,7 @@ const InvitationMembers = ({ dashboardId, createdByMe }) => {
             ))}
         {memberList && memberList?.length > visibleMembersNum && (
           <li>
-            <div className={cx('hidden-members-num')}>
+            <div className={cx('members-list-num')}>
               +{memberList?.slice(visibleMembersNum).length}
             </div>
           </li>

--- a/src/components/common/MemberPopup/MemberPopup.module.scss
+++ b/src/components/common/MemberPopup/MemberPopup.module.scss
@@ -1,0 +1,67 @@
+.container {
+  width: 22rem;
+  padding: 1.6rem;
+  padding-bottom: 0;
+  background-color: $gray90;
+  border: 0.2rem solid $gray70;
+  border-radius: 1.6rem;
+  box-shadow: $dropdown-shadow;
+}
+
+.info {
+  @include flexbox(start, $gap: 0.8rem);
+
+  margin-bottom: 1.6rem;
+
+  &-title {
+    @include text-style(18, bold);
+  }
+
+  &-count {
+    @include flexbox;
+    @include text-style(12, $gray20);
+
+    height: 2.4rem;
+    padding: 0 0.8rem;
+    background-color: #24252d;
+    border-radius: 0.4rem;
+  }
+}
+
+.member-list {
+  @include column-flexbox(start);
+
+  max-height: 25.5rem;
+  padding-right: 1rem;
+  padding-bottom: 0.8rem;
+  overflow-y: auto;
+
+  &::-webkit-scrollbar {
+    width: 0.6rem;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background-color: $gray40;
+    border-radius: 99rem;
+  }
+
+  &::-webkit-scrollbar-track {
+    background-color: transparent;
+  }
+
+  &-item {
+    @include flexbox(between);
+
+    width: 100%;
+    padding: 0.8rem 0;
+    border-bottom: 0.1rem solid $gray70;
+
+    &:last-child {
+      border-bottom: none;
+    }
+
+    &-name {
+      @include text-style(14, $gray10);
+    }
+  }
+}

--- a/src/components/common/MemberPopup/index.jsx
+++ b/src/components/common/MemberPopup/index.jsx
@@ -1,0 +1,29 @@
+import classNames from 'classnames/bind';
+import Avatar from '@/components/common/Avatar';
+import styles from './MemberPopup.module.scss';
+
+const cx = classNames.bind(styles);
+
+const MemberPopup = ({ memberList }) => (
+  <div className={cx('container')}>
+    <div className={cx('info')}>
+      <span className={cx('info-title')}>Member</span>
+      <span className={cx('info-count')}>{memberList.length}</span>
+    </div>
+    <ul className={cx('member-list')}>
+      {memberList?.map((member) => (
+        <li className={cx('member-list-item')} key={`key-member-${member.id}`}>
+          <Avatar
+            userId={member.userId}
+            profileName={member.nickname}
+            profileImage={member.profileImageUrl}
+            avatarSize='md'
+          />
+          <span className={cx('member-list-item-name')}>{member.nickname}</span>
+        </li>
+      ))}
+    </ul>
+  </div>
+);
+
+export default MemberPopup;

--- a/src/components/layout/Header/BoardHeader.jsx
+++ b/src/components/layout/Header/BoardHeader.jsx
@@ -4,8 +4,11 @@ import classNames from 'classnames/bind';
 import Dashboard from '@/api/dashboards';
 import InvitationMembers from '@/components/common/InvitationMembers';
 import Breadcrumb from '@/components/common/Breadcrumb';
+import MemberPopup from '@/components/common/MemberPopup';
 import useDashBoardStore from '@/stores/useDashboardStore';
 import useAsync from '@/hooks/useAsync';
+import useGetMembers from '@/hooks/useGetMembers';
+import useTogglePopup from '@/hooks/useTogglePopup';
 import { ICON } from '@/constants';
 import { INIT_DASHBOARD_DATA } from '@/constants/initialDataType';
 import styles from './BoardHeader.module.scss';
@@ -16,6 +19,9 @@ const { settings } = ICON;
 const BoardHeader = ({ dashboardId }) => {
   useAsync(() => Dashboard.get(dashboardId), INIT_DASHBOARD_DATA);
   const { dashboard } = useDashBoardStore();
+  const { memberList } = useGetMembers({ dashboardId });
+
+  const { isOpen, popupRef, buttonRef, openPopup, closePopup } = useTogglePopup();
 
   return (
     <div className={cx('container')}>
@@ -27,11 +33,23 @@ const BoardHeader = ({ dashboardId }) => {
           </Link>
         )}
       </div>
-      <div className={cx('info-wrap')}>
-        <InvitationMembers
-          dashboardId={dashboardId}
-          createdByMe={dashboard?.createdByMe}
-        />
+      <div className={cx('info')}>
+        <div className={cx('info-invitation')}>
+          <InvitationMembers
+            dashBoardId={dashboardId}
+            createdByMe={dashboard?.createdByMe}
+            memberList={memberList}
+            isOpen={isOpen}
+            buttonRef={buttonRef}
+            openPopup={openPopup}
+            closePopup={closePopup}
+          />
+          {isOpen && (
+            <div className={cx('info-invitation-popup')} ref={popupRef}>
+              <MemberPopup memberList={memberList} />
+            </div>
+          )}
+        </div>
         <div className={cx('line')}></div>
         <Breadcrumb title={dashboard?.title} />
       </div>

--- a/src/components/layout/Header/BoardHeader.module.scss
+++ b/src/components/layout/Header/BoardHeader.module.scss
@@ -26,8 +26,25 @@
   }
 }
 
-.info-wrap {
+.info {
   @include flexbox($gap: 1.6rem);
+
+  &-invitation {
+    position: relative;
+
+    &-popup {
+      @include pos-center-x;
+
+      top: 5rem;
+      z-index: $modal-level;
+
+      @include responsive(M) {
+        right: 0;
+        left: auto;
+        transform: translateX(0);
+      }
+    }
+  }
 }
 
 .line {


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이 PR은 어떤 유형인가요?

- [ ] 리팩터링
- [x] 기능
- [ ] 버그 수정
- [ ] 최적화
- [ ] 문서 업데이트

## 설명
1. 대시보드에 누가 참여하고 있는지 보여주는 팝업을 구현하였습니다.
2. 텍스트를 더블클릭하면 영역에 파란색 배경이 나오는데 버튼 안에 있는 텍스트만 선택이 안되도록 스타일 속성을 추가하였습니다.

## 스크린샷, 녹화
![image](https://github.com/TickyTocky/TickyTocky/assets/96277798/6afe6082-2635-4e7d-94ae-9b0fbe9da562)

